### PR TITLE
Oracle database support

### DIFF
--- a/.github/workflows/ci-oraclel.yml
+++ b/.github/workflows/ci-oraclel.yml
@@ -1,0 +1,82 @@
+on:
+  - pull_request
+  - push
+
+name: ci-oracle
+
+jobs:
+  tests:
+    name: PHP ${{ matrix.php-version }}-oracle-${{ matrix.pgsql-version }}
+    env:
+      extensions: curl, intl, pdo, pdo_oci, oci8
+      key: cache-v1
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        php-version:
+          - "8.0"
+          - "8.1"
+
+    services:
+      oci:
+        image: wnameless/oracle-xe-11g-r2:latest
+        ports:
+          - 1521:1521
+        options: --name=oci
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup cache environment
+        id: cache-env
+        uses: shivammathur/cache-extensions@v1
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: ${{ env.extensions }}
+          key: ${{ env.key }}
+
+      - name: Cache extensions
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.cache-env.outputs.dir }}
+          key: ${{ steps.cache-env.outputs.key }}
+          restore-keys: ${{ steps.cache-env.outputs.key }}
+
+      - name: Install PHP with extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: ${{ env.extensions }}
+          ini-values: date.timezone='UTC'
+          coverage: pcov
+
+      - name: Determine composer cache directory
+        if: matrix.os == 'ubuntu-latest'
+        run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
+
+      - name: Cache dependencies installed with composer
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.COMPOSER_CACHE_DIR }}
+          key: php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-
+
+      - name: Install dependencies with composer
+        if: matrix.php-version != '8.1'
+        run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
+
+      - name: Install dependencies with composer php 8.1
+        if: matrix.php-version == '8.1'
+        run: composer update --ignore-platform-reqs --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
+
+      - name: Run oracle tests with phpunit
+        env:
+          DB: oracle
+        run: vendor/bin/phpunit --group driver-oracle --colors=always

--- a/src/Driver/Oracle/OracleCompiler.php
+++ b/src/Driver/Oracle/OracleCompiler.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Driver\Oracle;
+
+use Cycle\Database\Driver\Compiler;
+use Cycle\Database\Driver\Quoter;
+use Cycle\Database\Injection\Fragment;
+use Cycle\Database\Injection\Parameter;
+use Cycle\Database\Query\QueryParameters;
+
+class OracleCompiler extends Compiler
+{
+    /**
+     * Column to be used as ROW_NUMBER in fallback selection mechanism, attention! Amount of columns
+     * in result set will be increaced by 1!
+     */
+    public const ROW_NUMBER = '_ROW_NUMBER_';
+
+    /**
+     * {@inheritdoc}
+     *
+     * Attention, limiting and ordering UNIONS will fail in SQL SERVER < 2012.
+     * For future upgrades: think about using top command.
+     *
+     * @link http://stackoverflow.com/questions/603724/how-to-implement-limit-with-microsoft-sql-server
+     * @link http://stackoverflow.com/questions/971964/limit-10-20-in-sql-server
+     */
+    protected function selectQuery(QueryParameters $params, Quoter $q, array $tokens): string
+    {
+        $limit = $tokens['limit'];
+        $offset = $tokens['offset'];
+
+        if (($limit === null && $offset === null) || $tokens['orderBy'] !== []) {
+            //When no limits are specified we can use normal query syntax
+            return call_user_func_array([$this, 'baseSelect'], func_get_args());
+        }
+
+        /**
+         * We are going to use fallback mechanism here in order to properly select limited data from
+         * database. Avoid usage of LIMIT/OFFSET without proper ORDER BY statement.
+         *
+         * Please see set of alerts raised in SelectQuery builder.
+         */
+        $tokens['columns'][] = new Fragment(
+            sprintf(
+                'ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS %s',
+                $this->name($params, $q, self::ROW_NUMBER)
+            )
+        );
+
+        $tokens['limit'] = null;
+        $tokens['offset'] = null;
+
+        return sprintf(
+            "SELECT * FROM (\n%s\n) AS [ORD_FALLBACK] %s",
+            $this->baseSelect($params, $q, $tokens),
+            $this->limit($params, $q, $limit, $offset, self::ROW_NUMBER)
+        );
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * SELECT ... FOR UPDATE
+     * @see https://www.devtechinfo.com/oracle-plsql-select-update-statement/
+     * CURSOR_cursor name IS select_statement FOR UPDATE [OF column_list] [NOWAIT];
+     */
+    private function baseSelect(QueryParameters $params, Quoter $q, array $tokens): string
+    {
+        // This statement(s) parts should be processed first to define set of table and column aliases
+        $tables = [];
+        foreach ($tokens['from'] as $table) {
+            $tables[] = $this->name($params, $q, $table, true);
+        }
+
+        $joins = $this->joins($params, $q, $tokens['join']);
+
+        return sprintf(
+            "SELECT%s %s\nFROM %s%s%s%s%s%s%s%s%s",
+            $this->optional(' ', $this->distinct($params, $q, $tokens['distinct'])),
+            $this->columns($params, $q, $tokens['columns']),
+            implode(', ', $tables),
+            $this->optional(' ', $joins, ' '),
+            $this->optional("\nWHERE", $this->where($params, $q, $tokens['where'])),
+            $this->optional("\nGROUP BY", $this->groupBy($params, $q, $tokens['groupBy']), ' '),
+            $this->optional("\nHAVING", $this->where($params, $q, $tokens['having'])),
+            $this->optional("\n", $this->unions($params, $q, $tokens['union'])),
+            $this->optional("\nORDER BY", $this->orderBy($params, $q, $tokens['orderBy'])),
+            $this->optional("\n", $this->limit($params, $q, $tokens['limit'], $tokens['offset'])),
+            $this->optional(' ', $tokens['forUpdate'] ? 'FOR UPDATE' : '', ' ')
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param string $rowNumber Row used in a fallback sorting mechanism, ONLY when no ORDER BY
+     *                          specified.
+     *
+     * @link https://www.oracletutorial.com/oracle-basics/oracle-fetch/
+     */
+    protected function limit(
+        QueryParameters $params,
+        Quoter $q,
+        int $limit = null,
+        int $offset = null,
+        string $rowNumber = null
+    ): string {
+        if ($limit === null && $offset === null) {
+            return '';
+        }
+
+        //Modern SQLServer are easier to work with
+        if ($rowNumber === null) {
+            $statement = 'OFFSET ? ROWS ';
+            $params->push(new Parameter((int)$offset));
+
+            if ($limit !== null) {
+                $statement .= 'FETCH FIRST ? ROWS ONLY';
+                $params->push(new Parameter($limit));
+            }
+
+            return trim($statement);
+        }
+
+        $statement = "WHERE {$this->name($params, $q, $rowNumber)} ";
+
+        //0 = row_number(1)
+        ++$offset;
+
+        if ($limit !== null) {
+            $statement .= 'BETWEEN ? AND ?';
+            $params->push(new Parameter((int)$offset));
+            $params->push(new Parameter($offset + $limit - 1));
+        } else {
+            $statement .= '>= ?';
+            $params->push(new Parameter((int)$offset));
+        }
+
+        return $statement;
+    }
+
+}

--- a/src/Driver/Oracle/OracleDriver.php
+++ b/src/Driver/Oracle/OracleDriver.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Driver\Oracle;
+
+use Cycle\Database\Driver\Driver;
+use Cycle\Database\Exception\StatementException;
+use Cycle\Database\Query\QueryBuilder;
+use Throwable;
+
+class OracleDriver extends Driver
+{
+    /**
+     * Default public schema name for all postgres connections.
+     *
+     * @var non-empty-string
+     */
+    public const PUBLIC_SCHEMA = 'SYSTEM';
+
+    /**
+     * Option key for all available postgres schema names.
+     *
+     * @var non-empty-string
+     */
+    private const OPT_AVAILABLE_SCHEMAS = 'schema';
+
+    /**
+     * Schemas to search tables in
+     *
+     * @var string[]
+     * @psalm-var non-empty-array<non-empty-string>
+     */
+    private array $searchSchemas = [];
+
+    /**
+     * @param array $options
+     */
+    public function __construct(array $options)
+    {
+        parent::__construct(
+            $options,
+            new OracleHandler(),
+            new OracleCompiler('""'),
+            QueryBuilder::defaultBuilder()
+        );
+
+        $this->defineSchemas($this->options);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getType(): string
+    {
+        return 'Oracle';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSource(): string
+    {
+        // remove "oci:"
+        return substr($this->getDSN(), 4);
+    }
+
+    /**
+     * Schemas to search tables in
+     *
+     * @return string[]
+     */
+    public function getSearchSchemas(): array
+    {
+        return $this->searchSchemas;
+    }
+
+    /**
+     * Check if schemas are defined
+     *
+     * @return bool
+     */
+    public function shouldUseDefinedSchemas(): bool
+    {
+        return $this->searchSchemas !== [];
+    }
+
+    /**
+     * Parse the table name and extract the schema and table.
+     *
+     * @param  string  $name
+     * @return string[]
+     */
+    public function parseSchemaAndTable(string $name): array
+    {
+        $schema = null;
+        $table = $name;
+
+        if (str_contains($name, '.')) {
+            [$schema, $table] = explode('.', $name, 2);
+
+            if ($schema === '$user') {
+                $schema = $this->options['username'];
+            }
+        }
+
+        return [$schema ?? $this->searchSchemas[0], $table];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function mapException(Throwable $exception, string $query): StatementException
+    {
+        if ((int)$exception->getCode() === 23000) {
+            return new StatementException\ConstrainException($exception, $query);
+        }
+
+        return new StatementException($exception, $query);
+    }
+
+    /**
+     * Define schemas from config
+     */
+    private function defineSchemas(array $options): void
+    {
+        $options[self::OPT_AVAILABLE_SCHEMAS] = (array)($options[self::OPT_AVAILABLE_SCHEMAS] ?? []);
+
+        $defaultSchema = static::PUBLIC_SCHEMA;
+
+        $this->searchSchemas = array_values(array_unique(
+            [$defaultSchema, ...$options[self::OPT_AVAILABLE_SCHEMAS]]
+        ));
+    }
+}

--- a/src/Driver/Oracle/OracleHandler.php
+++ b/src/Driver/Oracle/OracleHandler.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Driver\Oracle;
+
+use Cycle\Database\Driver\Handler;
+use Cycle\Database\Driver\Oracle\Schema\OracleColumn;
+use Cycle\Database\Driver\Oracle\Schema\OracleTable;
+use Cycle\Database\Exception\SchemaException;
+use Cycle\Database\Schema\AbstractColumn;
+use Cycle\Database\Schema\AbstractTable;
+
+class OracleHandler extends Handler
+{
+    public function getTableNames(string $prefix = ''): array
+    {
+        $query = "SELECT TABLE_NAME, TABLESPACE_NAME
+            FROM ALL_TABLES
+            WHERE TABLESPACE_NAME in ('" . implode("','", $this->driver->getSearchSchemas()) . "')";
+
+        $tables = [];
+        foreach ($this->driver->query($query) as $row) {
+            if ($prefix !== '' && strpos($row['TABLE_NAME'], $prefix) !== 0) {
+                continue;
+            }
+
+            $tables[] = $row['TABLESPACE_NAME'] . '.' . $row['TABLE_NAME'];
+        }
+
+        return $tables;
+    }
+
+    public function hasTable(string $table): bool
+    {
+        [$schema, $name] = $this->driver->parseSchemaAndTable($table);
+
+        $query = "SELECT COUNT(TABLE_NAME)
+            FROM ALL_TABLES
+            WHERE TABLESPACE_NAME = ?
+            AND TABLE_NAME = ?";
+
+        return (bool)$this->driver->query($query, [$schema, $name])->fetchColumn();
+    }
+
+    public function getSchema(string $table, string $prefix = null): AbstractTable
+    {
+        return new OracleTable($this->driver, $table, $prefix ?? '');
+    }
+
+    public function eraseTable(AbstractTable $table): void
+    {
+        // TODO: Implement eraseTable() method.
+    }
+
+    public function alterColumn(AbstractTable $table, AbstractColumn $initial, AbstractColumn $column): void
+    {
+        if (!$initial instanceof OracleColumn || !$column instanceof OracleColumn) {
+            throw new SchemaException('Oracle handler can work only with Oracle columns');
+        }
+
+        //Rename is separate operation
+        if ($column->getName() !== $initial->getName()) {
+            $this->renameColumn($table, $initial, $column);
+
+            //This call is required to correctly built set of alter operations
+            $initial->setName($column->getName());
+        }
+
+        //Oracle columns should be altered using set of operations
+        $operations = $column->alterOperations($this->driver, $initial);
+        if (empty($operations)) {
+            return;
+        }
+
+        //Oracle columns should be altered using set of operations
+        $query = sprintf(
+            'ALTER TABLE %s %s',
+            $this->identify($table),
+            trim(implode(', ', $operations), ', ')
+        );
+
+        $this->run($query);
+    }
+
+    /**
+     * @param AbstractTable  $table
+     * @param AbstractColumn $initial
+     * @param AbstractColumn $column
+     */
+    private function renameColumn(
+        AbstractTable $table,
+        AbstractColumn $initial,
+        AbstractColumn $column
+    ): void {
+        $statement = sprintf(
+            'ALTER TABLE %s RENAME COLUMN %s TO %s',
+            $this->identify($table),
+            $this->identify($initial),
+            $this->identify($column)
+        );
+
+        $this->run($statement);
+    }
+}

--- a/src/Driver/Oracle/Schema/OracleColumn.php
+++ b/src/Driver/Oracle/Schema/OracleColumn.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Driver\Oracle\Schema;
+
+use Cycle\Database\Driver\DriverInterface;
+use Cycle\Database\Schema\AbstractColumn;
+
+class OracleColumn extends AbstractColumn
+{
+    /**
+     * Default timestamp expression (driver specific).
+     */
+    public const DATETIME_NOW = 'CURRENT_TIMESTAMP';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $mapping = [
+        //Primary sequences
+        'primary'     => [
+            'type'          => 'number',
+            'size'          => 11,
+            'autoIncrement' => true,
+            'nullable'      => false,
+        ],
+        'bigPrimary'  => [
+            'type'          => 'number',
+            'size'          => 20,
+            'autoIncrement' => true,
+            'nullable'      => false,
+        ],
+
+        //Enum type (mapped via method)
+        'enum'        => 'enum',
+
+        //Logical types
+        'boolean'     => ['type' => 'tinyint', 'size' => 1],
+
+        //Integer types (size can always be changed with size method), longInteger has method alias
+        //bigInteger
+        'integer'     => ['type' => 'number', 'size' => 11],
+        'tinyInteger' => ['type' => 'number', 'size' => 4],
+        'bigInteger'  => ['type' => 'number', 'size' => 20],
+
+        //String with specified length (mapped via method)
+        'string'      => ['type' => 'varchar2', 'size' => 255],
+
+        //Generic types
+        'text'        => 'long',
+        'tinyText'    => 'char',
+        'longText'    => 'long',
+
+        //Real types
+        'double'      => 'numeric',
+        'float'       => 'float',
+
+        //Decimal type (mapped via method)
+        'decimal'     => 'decimal',
+
+        //Date and Time types
+        'datetime'    => 'datetime',
+        'date'        => 'date',
+        'time'        => 'time',
+        'timestamp'   => ['type' => 'timestamp', 'defaultValue' => null],
+
+        //Binary types
+        'binary'      => 'blob',
+        'tinyBinary'  => 'blob',
+        'longBinary'  => 'blob',
+
+        //Additional types
+        'json'        => 'text',
+        'uuid'        => ['type' => 'varchar2', 'size' => 36],
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $reverseMapping = [
+        'primary'     => [['type' => 'int', 'autoIncrement' => true]],
+        'bigPrimary'  => ['serial', ['type' => 'bigint', 'autoIncrement' => true]],
+        'enum'        => ['enum'],
+        'boolean'     => ['bool', 'boolean', ['type' => 'tinyint', 'size' => 1]],
+        'integer'     => ['int', 'integer', 'smallint', 'mediumint'],
+        'tinyInteger' => ['tinyint'],
+        'bigInteger'  => ['bigint'],
+        'string'      => ['varchar', 'char'],
+        'text'        => ['text', 'mediumtext'],
+        'tinyText'    => ['tinytext'],
+        'longText'    => ['longtext'],
+        'double'      => ['double'],
+        'float'       => ['float', 'real'],
+        'decimal'     => ['decimal'],
+        'datetime'    => ['datetime'],
+        'date'        => ['date'],
+        'time'        => ['time'],
+        'timestamp'   => ['timestamp'],
+        'binary'      => ['blob', 'binary', 'varbinary'],
+        'tinyBinary'  => ['tinyblob'],
+        'longBinary'  => ['longblob'],
+    ];
+
+    /**
+     * List of types forbids default value set.
+     *
+     * @var array
+     */
+    protected $forbiddenDefaults = [
+        'text',
+        'mediumtext',
+        'tinytext',
+        'longtext',
+        'blog',
+        'tinyblob',
+        'longblob',
+    ];
+
+    /**
+     * Column is auto incremental.
+     *
+     * @var bool
+     */
+    protected $autoIncrement = false;
+
+
+
+    /**
+     * @param string          $table  Table name.
+     * @param array           $schema
+     * @param DriverInterface $driver Postgres columns are bit more complex.
+     * @return OracleColumn
+     */
+    public static function createInstance(
+        string $table,
+        array $schema,
+        DriverInterface $driver
+    ): self {
+        $column = new self($table, $schema['COLUMN_NAME'], $driver->getTimezone());
+
+        $column->type = $schema['DATA_TYPE'];
+        $column->defaultValue = $schema['DATA_DEFAULT'];
+        $column->nullable = $schema['NULLABLE'] === 'Y';
+
+        if (strpos($column->type, 'char') !== false && $schema['character_maximum_length']) {
+            $column->size = $schema['character_maximum_length'];
+        }
+
+        if ($column->type === 'number') {
+            $column->precision = $schema['numeric_precision'];
+            $column->scale = $schema['numeric_scale'];
+        }
+
+        return $column;
+    }
+}

--- a/src/Driver/Oracle/Schema/OracleForeignKey.php
+++ b/src/Driver/Oracle/Schema/OracleForeignKey.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Driver\Oracle\Schema;
+
+use Cycle\Database\Schema\AbstractForeignKey;
+
+class OracleForeignKey extends AbstractForeignKey
+{
+    public static function createInstance(string $table, string $tablePrefix, array $schema): self
+    {
+        $reference = new self($table, $tablePrefix, $schema['CONSTRAINT_NAME']);
+
+        $reference->columns = $schema['COLUMN_NAME'];
+        $reference->foreignTable = $schema['r_table_name'];
+        $reference->foreignKeys = $schema['r_column_name'];
+
+        $reference->deleteRule = $schema['DELETE_RULE'];
+
+        return $reference;
+    }
+}

--- a/src/Driver/Oracle/Schema/OracleIndex.php
+++ b/src/Driver/Oracle/Schema/OracleIndex.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Driver\Oracle\Schema;
+
+use Cycle\Database\Schema\AbstractIndex;
+
+class OracleIndex extends AbstractIndex
+{
+    public static function createInstance(string $table, string $name, array $schema): self
+    {
+        $index = new self($table, $name);
+
+        foreach ($schema as $definition) {
+            $index->type = $definition['UNIQUENESS'] === 'UNIQUE' ? self::UNIQUE : self::NORMAL;
+            $index->columns[] = $definition['COLUMN_NAME'];
+            if ($definition['DESCEND'] !== 'ASC') {
+                $index->sort[$definition['COLUMN_NAME']] = 'DESC';
+            }
+        }
+
+        return $index;
+    }
+}

--- a/src/Driver/Oracle/Schema/OracleTable.php
+++ b/src/Driver/Oracle/Schema/OracleTable.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Driver\Oracle\Schema;
+
+use Cycle\Database\Schema\AbstractColumn;
+use Cycle\Database\Schema\AbstractForeignKey;
+use Cycle\Database\Schema\AbstractIndex;
+use Cycle\Database\Schema\AbstractTable;
+
+class OracleTable extends AbstractTable
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return $this->removeSchemaFromTableName($this->getFullName());
+    }
+
+    protected function fetchColumns(): array
+    {
+        [$tableSchema, $tableName] = $this->driver->parseSchemaAndTable($this->getFullName());
+
+        $query = $this->driver->query(
+            'select col.column_id, 
+                           col.column_name, 
+                           col.data_type, 
+                           col.data_length, 
+                           col.data_default, 
+                           col.data_precision, 
+                           col.data_scale, 
+                           col.nullable
+                    from ALL_TAB_COLUMNS col
+                    inner join sys.all_tables t on col.owner = t.owner and col.table_name = t.table_name
+                    where col.owner = ?
+                    and col.table_name = ?
+                    order by col.column_id',
+            [$tableSchema, $tableName]
+        );
+
+        $result = [];
+        foreach ($query->fetchAll() as $schema) {
+            $result[] = OracleColumn::createInstance($tableSchema . '.' . $tableName, $schema, $this->driver);
+        }
+
+        return $result;
+    }
+
+    protected function fetchIndexes(): array
+    {
+        [$tableSchema, $tableName] = $this->driver->parseSchemaAndTable($this->getFullName());
+
+        $query = $this->driver->query(
+            'select ALL_INDEXES.INDEX_NAME, ALL_IND_COLUMNS.COLUMN_NAME, ALL_IND_COLUMNS.DESCEND, 
+                            ALL_INDEXES.UNIQUENESS
+                    from ALL_INDEXES
+                    join ALL_IND_COLUMNS
+                        on ALL_INDEXES.INDEX_NAME = ALL_IND_COLUMNS.INDEX_NAME
+                        and ALL_INDEXES.OWNER = ALL_IND_COLUMNS.INDEX_OWNER
+                    where ALL_INDEXES.owner = ?
+                    and ALL_INDEXES.table_name = ?
+                    and ALL_INDEXES.table_type = ?
+                    order by ALL_IND_COLUMNS.COLUMN_POSITION',
+            [$tableSchema, $tableName, 'TABLE']
+        );
+
+        //Gluing all index definitions together
+        $schemas = [];
+        foreach ($query as $index) {
+            $schemas[$index['INDEX_NAME']][] = $index;
+        }
+
+        $result = [];
+        foreach ($schemas as $name => $index) {
+            $result[] = OracleIndex::createInstance($this->getFullName(), $name, $index);
+        }
+
+        return $result;
+    }
+
+    protected function fetchReferences(): array
+    {
+        [$tableSchema, $tableName] = $this->driver->parseSchemaAndTable($this->getFullName());
+
+        $query = $this->driver->query(
+            'SELECT a.table_name, a.column_name, a.constraint_name, c.owner, c.delete_rule, 
+                       -- referenced pk
+                       c.r_owner, c_pk.table_name r_table_name, c_pk.constraint_name r_pk, a_pk.column_name r_column_name
+                      FROM all_cons_columns a
+                      JOIN all_constraints c ON a.owner = c.owner AND a.constraint_name = c.constraint_name
+                      JOIN all_constraints c_pk ON c.r_owner = c_pk.owner AND c.r_constraint_name = c_pk.constraint_name
+                      JOIN all_cons_columns a_pk ON a_pk.owner = c_pk.owner AND a_pk.constraint_name = c_pk.constraint_name
+                    where a.owner = ?
+                    and a.table_name = ?
+                    and c.constraint_type = ?
+                    order by a.table_name, a.position',
+            [$tableSchema, $tableName, 'R']
+        );
+
+        $result = [];
+        foreach ($query as $index) {
+            $result[] = OracleForeignKey::createInstance(
+                $this->getFullName(),
+                $this->getPrefix(),
+                $index
+            );
+        }
+
+        return $result;
+    }
+
+    protected function fetchPrimaryKeys(): array
+    {
+        [$tableSchema, $tableName] = $this->driver->parseSchemaAndTable($this->getFullName());
+
+        $query = $this->driver->query(
+            'select *
+                    from ALL_CONSTRAINTS
+                    join ALL_CONS_COLUMNS 
+                        on ALL_CONS_COLUMNS.CONSTRAINT_NAME = ALL_CONSTRAINTS.CONSTRAINT_NAME
+                        and ALL_CONS_COLUMNS.OWNER = ALL_CONSTRAINTS.OWNER
+                    where ALL_CONSTRAINTS.owner = ?
+                    and ALL_CONSTRAINTS.table_name = ?
+                    and ALL_CONSTRAINTS.CONSTRAINT_TYPE = ?
+                    order by ALL_CONS_COLUMNS.TABLE_NAME, ALL_CONS_COLUMNS.POSITION',
+            [$tableSchema, $tableName, 'P']
+        );
+
+        $primaryKeys = [];
+        foreach ($query as $index) {
+            $primaryKeys[] = $index['COLUMN_NAME'];
+        }
+
+        return $primaryKeys;
+    }
+
+    protected function createColumn(string $name): AbstractColumn
+    {
+        return new OracleColumn(
+            $this->getNormalizedTableName(),
+            $this->removeSchemaFromTableName($name),
+            $this->driver->getTimezone()
+        );
+    }
+
+    protected function createIndex(string $name): AbstractIndex
+    {
+        return new OracleIndex($this->getFullName(), $name);
+    }
+
+    protected function createForeign(string $name): AbstractForeignKey
+    {
+        return new OracleForeignKey($this->getFullName(), $this->getPrefix(), $name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function prefixTableName(string $name): string
+    {
+        [$schema, $name] = $this->driver->parseSchemaAndTable($name);
+
+        return $schema . '.' . parent::prefixTableName($name);
+    }
+
+    /**
+     * Get table name with schema. If table doesn't contain schema, schema will be added from config
+     *
+     * @return string
+     */
+    protected function getNormalizedTableName(): string
+    {
+        [$schema, $name] = $this->driver->parseSchemaAndTable($this->getFullName());
+
+        return $schema . '.' . $name;
+    }
+
+    /**
+     * Return table name without schema
+     *
+     * @param string $name
+     * @return string
+     */
+    protected function removeSchemaFromTableName(string $name): string
+    {
+        if (strpos($name, '.') !== false) {
+            [, $name] = explode('.', $name, 2);
+        }
+
+        return $name;
+    }
+}

--- a/tests/Database/Driver/Oracle/AlterColumnTest.php
+++ b/tests/Database/Driver/Oracle/AlterColumnTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class AlterColumnTest extends \Cycle\Database\Tests\AlterColumnTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/BuildersAccessTest.php
+++ b/tests/Database/Driver/Oracle/BuildersAccessTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class BuildersAccessTest extends \Cycle\Database\Tests\BuildersAccessTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/ConsistencyTest.php
+++ b/tests/Database/Driver/Oracle/ConsistencyTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class ConsistencyTest extends \Cycle\Database\Tests\ConsistencyTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/CreateTableTest.php
+++ b/tests/Database/Driver/Oracle/CreateTableTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class CreateTableTest extends \Cycle\Database\Tests\CreateTableTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/DatabaseTest.php
+++ b/tests/Database/Driver/Oracle/DatabaseTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class DatabaseTest extends \Cycle\Database\Tests\DatabaseTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/DatetimeColumnTest.php
+++ b/tests/Database/Driver/Oracle/DatetimeColumnTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class DatetimeColumnTest extends \Cycle\Database\Tests\DatetimeColumnTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/DefaultValueTest.php
+++ b/tests/Database/Driver/Oracle/DefaultValueTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class DefaultValueTest extends \Cycle\Database\Tests\DefaultValueTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/DeleteQueryTest.php
+++ b/tests/Database/Driver/Oracle/DeleteQueryTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class DeleteQueryTest extends \Cycle\Database\Tests\DeleteQueryTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/ExceptionsTest.php
+++ b/tests/Database/Driver/Oracle/ExceptionsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class ExceptionsTest extends \Cycle\Database\Tests\ExceptionsTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/ForeignKeysTest.php
+++ b/tests/Database/Driver/Oracle/ForeignKeysTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class ForeignKeysTest extends \Cycle\Database\Tests\ForeignKeysTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/IndexesTest.php
+++ b/tests/Database/Driver/Oracle/IndexesTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class IndexesTest extends \Cycle\Database\Tests\IndexesTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/InsertQueryTest.php
+++ b/tests/Database/Driver/Oracle/InsertQueryTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class InsertQueryTest extends \Cycle\Database\Tests\InsertQueryTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/IsolationTest.php
+++ b/tests/Database/Driver/Oracle/IsolationTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class IsolationTest extends \Cycle\Database\Tests\IsolationTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/NestedQueriesTest.php
+++ b/tests/Database/Driver/Oracle/NestedQueriesTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class NestedQueriesTest extends \Cycle\Database\Tests\NestedQueriesTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/ReflectorTest.php
+++ b/tests/Database/Driver/Oracle/ReflectorTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class ReflectorTest extends \Cycle\Database\Tests\ReflectorTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/SelectQueryTest.php
+++ b/tests/Database/Driver/Oracle/SelectQueryTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class SelectQueryTest extends \Cycle\Database\Tests\SelectQueryTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/StatementTest.php
+++ b/tests/Database/Driver/Oracle/StatementTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class StatementTest extends \Cycle\Database\Tests\StatementTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/TableTest.php
+++ b/tests/Database/Driver/Oracle/TableTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class TableTest extends \Cycle\Database\Tests\TableTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/TransactionsTest.php
+++ b/tests/Database/Driver/Oracle/TransactionsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class TransactionsTest extends \Cycle\Database\Tests\TransactionsTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/Database/Driver/Oracle/UpdateQueryTest.php
+++ b/tests/Database/Driver/Oracle/UpdateQueryTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Driver\Oracle;
+
+/**
+ * @group driver
+ * @group driver-oracle
+ */
+class UpdateQueryTest extends \Cycle\Database\Tests\UpdateQueryTest
+{
+    const DRIVER = "oracle";
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -49,6 +49,13 @@ $drivers = [
         'pass'       => 'SSpaSS__1',
         'queryCache' => 100
     ],
+    'oracle' => [
+        'driver'     => Database\Driver\Oracle\OracleDriver::class,
+        'conn'       => 'oci:host=oracle;port=1521;dbname=oracle/xe',
+        'user'       => 'SYSTEM',
+        'pass'       => 'oracle',
+        'queryCache' => 100
+    ],
 ];
 
 $db = getenv('DB') ?: null;

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,32 +1,53 @@
 version: "3"
 
 services:
-  sqlserver:
-    image: mcr.microsoft.com/mssql/server:2019-latest
-    restart: always
-    ports:
-      - "11433:1433"
-    environment:
-      SA_PASSWORD: "SSpaSS__1"
-      ACCEPT_EULA: "Y"
+#  sqlserver:
+#    image: mcr.microsoft.com/mssql/server:2019-latest
+#    restart: always
+#    ports:
+#      - "11433:1433"
+#    environment:
+#      SA_PASSWORD: "SSpaSS__1"
+#      ACCEPT_EULA: "Y"
+#
+#  mysql_latest:
+#    image: mysql:latest
+#    restart: always
+#    command: --default-authentication-plugin=mysql_native_password
+#    ports:
+#      - "13306:3306"
+#    environment:
+#      MYSQL_DATABASE: "spiral"
+#      MYSQL_ROOT_PASSWORD: "root"
+#      MYSQL_ROOT_HOST: "%"
+#
+#  postgres:
+#    image: postgres:12
+#    restart: always
+#    ports:
+#      - "15432:5432"
+#    environment:
+#      POSTGRES_DB: "spiral"
+#      POSTGRES_USER: "postgres"
+#      POSTGRES_PASSWORD: "postgres"
 
-  mysql_latest:
-    image: mysql:latest
-    restart: always
-    command: --default-authentication-plugin=mysql_native_password
-    ports:
-      - "13306:3306"
-    environment:
-      MYSQL_DATABASE: "spiral"
-      MYSQL_ROOT_PASSWORD: "root"
-      MYSQL_ROOT_HOST: "%"
+  php:
+    build: "./php"
+    command: /app/vendor/bin/phpunit -c /app/phpunit.xml --filter Oracle /app/tests
+    volumes:
+      - ../:/app
+    depends_on:
+      - oracle
 
-  postgres:
-    image: postgres:12
+  oracle:
+    image: wnameless/oracle-xe-11g-r2:latest
     restart: always
     ports:
-      - "15432:5432"
+      - 11521:1521
     environment:
-      POSTGRES_DB: "spiral"
-      POSTGRES_USER: "postgres"
-      POSTGRES_PASSWORD: "postgres"
+      WEB_CONSOLE: "false"
+    # sid: xe
+    # service name: xe
+    # username: system
+    # password: oracle
+    # Password for SYS & SYSTEM oracle

--- a/tests/generate.php
+++ b/tests/generate.php
@@ -35,6 +35,10 @@ $databases = [
     'sqlserver' => [
         'namespace' => 'Cycle\Database\Tests\Driver\SQLServer',
         'directory' => __DIR__ . '/Database/Driver/SQLServer/'
+    ],
+    'oracle' => [
+        'namespace' => 'Cycle\Database\Tests\Driver\Oracle',
+        'directory' => __DIR__ . '/Database/Driver/Oracle/'
     ]
 ];
 

--- a/tests/install-oci8.sh
+++ b/tests/install-oci8.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -ex
+
+sudo apt-get install unzip
+sudo rm -rf /opt/oracle
+sudo mkdir -p /opt/oracle
+
+sudo curl -o /opt/oracle/basic.zip https://download.oracle.com/otn_software/linux/instantclient/213000/instantclient-basic-linux.x64-21.3.0.0.0.zip
+sudo curl -o /opt/oracle/sdk.zip https://download.oracle.com/otn_software/linux/instantclient/213000/instantclient-sdk-linux.x64-21.3.0.0.0.zip
+
+sudo unzip /opt/oracle/basic.zip -d /opt/oracle
+sudo unzip /opt/oracle/sdk.zip -d /opt/oracle
+
+sudo ln -s /opt/oracle/instantclient_21_3 /opt/oracle/instantclient
+
+sudo rm /opt/oracle/instantclient/libclntsh.so
+sudo rm /opt/oracle/instantclient/libocci.so
+sudo ln -s /opt/oracle/instantclient/libclntsh.so.12.1 /opt/oracle/instantclient/libclntsh.so
+sudo ln -s /opt/oracle/instantclient/libocci.so.12.1 /opt/oracle/instantclient/libocci.so
+
+sudo sh -c 'echo /opt/oracle/instantclient > /etc/ld.so.conf.d/oracle-instantclient.conf'
+sudo apt-get install -y make php-dev php-pear build-essential libaio1
+sudo pecl channel-update pecl.php.net
+sudo pecl install oci8
+
+# When you are prompted for the Instant Client location, enter the following:
+# instantclient,/opt/oracle/instantclient

--- a/tests/php/Dockerfile
+++ b/tests/php/Dockerfile
@@ -1,0 +1,40 @@
+FROM php:8.0
+
+RUN apt-get update
+RUN apt-get install unzip
+
+RUN mkdir -p /opt/oracle
+
+RUN curl -o /opt/oracle/basic.zip https://download.oracle.com/otn_software/linux/instantclient/213000/instantclient-basic-linux.x64-21.3.0.0.0.zip
+RUN curl -o /opt/oracle/sdk.zip https://download.oracle.com/otn_software/linux/instantclient/213000/instantclient-sdk-linux.x64-21.3.0.0.0.zip
+
+RUN unzip /opt/oracle/basic.zip -d /opt/oracle
+RUN unzip /opt/oracle/sdk.zip -d /opt/oracle
+
+RUN ln -s /opt/oracle/instantclient_21_3 /opt/oracle/instantclient
+RUN rm /opt/oracle/instantclient/libclntsh.so
+RUN rm /opt/oracle/instantclient/libocci.so
+RUN rm /opt/oracle/instantclient/libclntshcore.so
+
+RUN ln -s /opt/oracle/instantclient/libclntsh.so.12.1 /opt/oracle/instantclient/libclntsh.so
+RUN ln -s /opt/oracle/instantclient/libclntshcore.so.12.1 /opt/oracle/instantclient/libclntshcore.so
+RUN ln -s /opt/oracle/instantclient/libocci.so.12.1 /opt/oracle/instantclient/libocci.so
+
+RUN sh -c 'echo /opt/oracle/instantclient > /etc/ld.so.conf.d/oracle-instantclient.conf'
+
+RUN apt-get install -y make build-essential libaio1
+RUN pecl channel-update pecl.php.net
+
+RUN echo 'instantclient,/opt/oracle/instantclient' | pecl install oci8 && ldconfig
+
+ENV ORACLE_HOME=/opt/oracle/instantclient
+ENV LD_LIBRARY_PATH /opt/oracle/instantclient
+
+RUN docker-php-ext-install pdo
+RUN docker-php-ext-configure pdo_oci --with-pdo-oci=instantclient,$ORACLE_HOME,12.1 && docker-php-ext-install pdo_oci
+RUN docker-php-ext-configure mysqli --with-mysqli=mysqlnd && docker-php-ext-install pdo_mysql
+
+RUN apt-get install -y libpq-dev
+RUN docker-php-ext-configure pgsql --with-pgsql=/usr/local/pgsql && docker-php-ext-install pgsql pdo_pgsql
+
+RUN apt-get clean -y && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- Added oracle driver
- Added tests for oracle driver
- Added oracle-xe-11g-r2 docker container
- Added docker container PHP with pdo_oci
- Added bash script with pdo_oci installer

## Oracle Features

### Uppercase
Naming system tables and fields in uppercase (at least in version 11). In SQL queries, lowercase can be used, but the returned arrays will have uppercase.

### Schemas
In Oracle, there's a concept called schema and by default, every user upon connection has access to a schema with the username. The work with schemas from the Postgres driver was used as a basis, as it is more similar to Oracle.

By default, after launching a Docker container, the user SYSTEM is available and it has a bunch of system tables. This feature can complicate testing the retrieval of the entire table list through `getTableNames`.

### Auto increment
In Oracle DB, auto increment is implemented through Sequences. It's necessary to create a Sequence, name it, and when adding a new record to the DB, specify which field should use which Sequence. There's no direct link between the table field and the sequence, i.e., it's impossible to know which field corresponds to which sequence.

**Creating a Sequence**
```sql
CREATE SEQUENCE author_seq
 START WITH     1
 INCREMENT BY   1
 NOCACHE
 NOCYCLE
```

**Inserting a row into the DB**
```sql
create table author(
   id             NUMBER(6) PRIMARY KEY,
   fname          VARCHAR2(20) NOT NULL,
   lname          VARCHAR2(20) NOT NULL,
   email          VARCHAR2(50),
   phone_number   VARCHAR2(20)
)

INSERT INTO author
VALUES
  (author_seq.nextval, 'Stephen', 'King', 'stephen@king.com', NULL)
```

Detailed example [here](https://livesql.oracle.com/apex/livesql/file/content_GL1PAE2CYMKDK32A42NZIGJVR.html)

### Column types

Oracle has its own typing for fields. You can view the list of types, for instance, [here](https://www.w3resource.com/oracle/oracle-data-types.php). Pay attention to this when mapping.

### LIMIT OFFSET

In Oracle, working with LIMIT OFFSET is similar to the SqlServer driver.

**Sample**

```sql
SELECT
    product_name,
    quantity
FROM
    inventories
INNER JOIN products
        USING(product_id)
ORDER BY
    quantity DESC 
FETCH NEXT 5 ROWS ONLY;
```

Note the syntax as there are [variations](https://www.oracletutorial.com/oracle-basics/oracle-fetch/).

```sql
[ OFFSET offset ROWS]
 FETCH  NEXT [  row_count | percent PERCENT  ] ROWS  [ ONLY | WITH TIES ] 
```

### SELECT ... FOR UPDATE

The SELECT FOR UPDATE command allows you to lock the records in the resulting cursor set. The record lock is released when the following commit or rollback commands are executed.

```sql
CURSOR c1
IS
  SELECT course_number, instructor
  FROM courses_tbl
  FOR UPDATE OF instructor;
```

### Foreign keys

As far as I understood, in version 11 of Oracle DB, there is no possibility to use `ON UPDATE`, instead triggers are suggested.

```sql
create table table1(
    column1 number primary key
);
create table table2(
    column2 number references table1(column1)
);

create or replace trigger cascade_update
after update of column1 on table1
for each row
begin
   update table2
   set column2 = :new.column1 
   where column2 = :old.column1;
end;
```

### Drop constraint drop index

Dropping an index with constraint is allowable as follows

```sql
alter table foo drop constraint un_foo drop index
```

There might be other specific things, possibly from version 11 Oracle added a bunch of innovations and it's worth updating the Docker container to the latest version. The current version is 21c.