### PR TITLE
Using Spiral/Database alias instead of Cycle/Database

### DIFF
--- a/resources/.phpstorm.meta.php
+++ b/resources/.phpstorm.meta.php
@@ -12,70 +12,70 @@ declare(strict_types=1);
 namespace Spiral\Database {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\ColumnInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\ColumnInterface instead.
      */
     interface ColumnInterface extends \Cycle\Database\ColumnInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\DatabaseInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\DatabaseInterface instead.
      */
     interface DatabaseInterface extends \Cycle\Database\DatabaseInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\DatabaseProviderInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\DatabaseProviderInterface instead.
      */
     interface DatabaseProviderInterface extends \Cycle\Database\DatabaseProviderInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\ForeignKeyInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\ForeignKeyInterface instead.
      */
     interface ForeignKeyInterface extends \Cycle\Database\ForeignKeyInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\IndexInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\IndexInterface instead.
      */
     interface IndexInterface extends \Cycle\Database\IndexInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\StatementInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\StatementInterface instead.
      */
     interface StatementInterface extends \Cycle\Database\StatementInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\TableInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\TableInterface instead.
      */
     interface TableInterface extends \Cycle\Database\TableInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Database instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Database instead.
      */
     final class Database extends \Cycle\Database\Database
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\DatabaseManager instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\DatabaseManager instead.
      */
     final class DatabaseManager extends \Cycle\Database\DatabaseManager
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Table instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Table instead.
      */
     final class Table extends \Cycle\Database\Table
     {
@@ -85,58 +85,65 @@ namespace Spiral\Database {
 namespace Spiral\Database\Schema {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Schema\ComparatorInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Schema\ComparatorInterface instead.
      */
     interface ComparatorInterface extends \Cycle\Database\Schema\ComparatorInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Schema\ElementInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Schema\ElementInterface instead.
      */
     interface ElementInterface extends \Cycle\Database\Schema\ElementInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Schema\AbstractColumn instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Schema\AbstractColumn instead.
      */
     abstract class AbstractColumn extends \Cycle\Database\Schema\AbstractColumn
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Schema\AbstractForeignKey instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Schema\AbstractForeignKey instead.
      */
     abstract class AbstractForeignKey extends \Cycle\Database\Schema\AbstractForeignKey
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Schema\AbstractIndex instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Schema\AbstractIndex instead.
      */
     abstract class AbstractIndex extends \Cycle\Database\Schema\AbstractIndex
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Schema\AbstractTable instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Schema\AbstractTable instead.
      */
     abstract class AbstractTable extends \Cycle\Database\Schema\AbstractTable
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Schema\Comparator instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Schema\Comparator instead.
      */
     final class Comparator extends \Cycle\Database\Schema\Comparator
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Schema\Reflector instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Schema\Reflector instead.
      */
     final class Reflector extends \Cycle\Database\Schema\Reflector
+    {
+    }
+
+    /**
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Schema\State instead.
+     */
+    final class State extends \Cycle\Database\Schema\State
     {
     }
 }
@@ -144,7 +151,7 @@ namespace Spiral\Database\Schema {
 namespace Spiral\Database\Schema\Traits {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Schema\Traits\ElementTrait instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Schema\Traits\ElementTrait instead.
      */
     trait ElementTrait
     {
@@ -155,70 +162,70 @@ namespace Spiral\Database\Schema\Traits {
 namespace Spiral\Database\Query {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Query\BuilderInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Query\BuilderInterface instead.
      */
     interface BuilderInterface extends \Cycle\Database\Query\BuilderInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Query\QueryInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Query\QueryInterface instead.
      */
     interface QueryInterface extends \Cycle\Database\Query\QueryInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Query\ActiveQuery instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Query\ActiveQuery instead.
      */
     abstract class ActiveQuery extends \Cycle\Database\Query\ActiveQuery
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Query\DeleteQuery instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Query\DeleteQuery instead.
      */
     class DeleteQuery extends \Cycle\Database\Query\DeleteQuery
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Query\InsertQuery instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Query\InsertQuery instead.
      */
     class InsertQuery extends \Cycle\Database\Query\InsertQuery
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Query\Interpolator instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Query\Interpolator instead.
      */
     final class Interpolator extends \Cycle\Database\Query\Interpolator
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Query\QueryBuilder instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Query\QueryBuilder instead.
      */
     final class QueryBuilder extends \Cycle\Database\Query\QueryBuilder
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Query\QueryParameters instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Query\QueryParameters instead.
      */
     final class QueryParameters extends \Cycle\Database\Query\QueryParameters
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Query\SelectQuery instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Query\SelectQuery instead.
      */
     class SelectQuery extends \Cycle\Database\Query\SelectQuery
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Query\UpdateQuery instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Query\UpdateQuery instead.
      */
     class UpdateQuery extends \Cycle\Database\Query\UpdateQuery
     {
@@ -228,7 +235,7 @@ namespace Spiral\Database\Query {
 namespace Spiral\Database\Query\Traits {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Query\Traits\HavingTrait instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Query\Traits\HavingTrait instead.
      */
     trait HavingTrait
     {
@@ -236,7 +243,7 @@ namespace Spiral\Database\Query\Traits {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Query\Traits\JoinTrait instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Query\Traits\JoinTrait instead.
      */
     trait JoinTrait
     {
@@ -244,7 +251,7 @@ namespace Spiral\Database\Query\Traits {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Query\Traits\TokenTrait instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Query\Traits\TokenTrait instead.
      */
     trait TokenTrait
     {
@@ -252,7 +259,7 @@ namespace Spiral\Database\Query\Traits {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Query\Traits\WhereTrait instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Query\Traits\WhereTrait instead.
      */
     trait WhereTrait
     {
@@ -263,42 +270,42 @@ namespace Spiral\Database\Query\Traits {
 namespace Spiral\Database\Injection {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Injection\FragmentInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Injection\FragmentInterface instead.
      */
     interface FragmentInterface extends \Cycle\Database\Injection\FragmentInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Injection\ParameterInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Injection\ParameterInterface instead.
      */
     interface ParameterInterface extends \Cycle\Database\Injection\ParameterInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Injection\ValueInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Injection\ValueInterface instead.
      */
     interface ValueInterface extends \Cycle\Database\Injection\ValueInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Injection\Expression instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Injection\Expression instead.
      */
     class Expression extends \Cycle\Database\Injection\Expression
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Injection\Fragment instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Injection\Fragment instead.
      */
     class Fragment extends \Cycle\Database\Injection\Fragment
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Injection\Parameter instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Injection\Parameter instead.
      */
     class Parameter extends \Cycle\Database\Injection\Parameter
     {
@@ -308,84 +315,84 @@ namespace Spiral\Database\Injection {
 namespace Spiral\Database\Exception {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Exception\StatementExceptionInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Exception\StatementExceptionInterface instead.
      */
     interface StatementExceptionInterface extends \Cycle\Database\Exception\StatementExceptionInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Exception\BuilderException instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Exception\BuilderException instead.
      */
     class BuilderException extends \Cycle\Database\Exception\BuilderException
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Exception\CompilerException instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Exception\CompilerException instead.
      */
     class CompilerException extends \Cycle\Database\Exception\CompilerException
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Exception\ConfigException instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Exception\ConfigException instead.
      */
     class ConfigException extends \Cycle\Database\Exception\ConfigException
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Exception\DatabaseException instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Exception\DatabaseException instead.
      */
     class DatabaseException extends \Cycle\Database\Exception\DatabaseException
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Exception\DBALException instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Exception\DBALException instead.
      */
     class DBALException extends \Cycle\Database\Exception\DBALException
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Exception\DefaultValueException instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Exception\DefaultValueException instead.
      */
     class DefaultValueException extends \Cycle\Database\Exception\DefaultValueException
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Exception\DriverException instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Exception\DriverException instead.
      */
     class DriverException extends \Cycle\Database\Exception\DriverException
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Exception\HandlerException instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Exception\HandlerException instead.
      */
     class HandlerException extends \Cycle\Database\Exception\HandlerException
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Exception\InterpolatorException instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Exception\InterpolatorException instead.
      */
     class InterpolatorException extends \Cycle\Database\Exception\InterpolatorException
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Exception\SchemaException instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Exception\SchemaException instead.
      */
     class SchemaException extends \Cycle\Database\Exception\SchemaException
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Exception\StatementExceptionInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Exception\StatementExceptionInterface instead.
      */
     class StatementException extends \Cycle\Database\Exception\StatementException
     {
@@ -395,14 +402,14 @@ namespace Spiral\Database\Exception {
 namespace Spiral\Database\Exception\StatementException {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Exception\StatementException\ConnectionException instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Exception\StatementException\ConnectionException instead.
      */
     class ConnectionException extends ConnectionException
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Exception\StatementException\ConnectionException instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Exception\StatementException\ConnectionException instead.
      */
     class ConstrainException extends ConstrainException
     {
@@ -412,77 +419,77 @@ namespace Spiral\Database\Exception\StatementException {
 namespace Spiral\Database\Driver {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\CachingCompilerInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\CachingCompilerInterface instead.
      */
     interface CachingCompilerInterface extends \Cycle\Database\Driver\CachingCompilerInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\CompilerInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\CompilerInterface instead.
      */
     interface CompilerInterface extends \Cycle\Database\Driver\CompilerInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\DriverInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\DriverInterface instead.
      */
     interface DriverInterface extends \Cycle\Database\Driver\DriverInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\HandlerInterface instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\HandlerInterface instead.
      */
     interface HandlerInterface extends \Cycle\Database\Driver\HandlerInterface
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\Compiler instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\Compiler instead.
      */
     abstract class Compiler extends \Cycle\Database\Driver\Compiler
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\Driver instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\Driver instead.
      */
     abstract class Driver extends \Cycle\Database\Driver\Driver
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\Handler instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\Handler instead.
      */
     abstract class Handler extends \Cycle\Database\Driver\Handler
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\CompilerCache instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\CompilerCache instead.
      */
     final class CompilerCache extends \Cycle\Database\Driver\CompilerCache
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\Quoter instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\Quoter instead.
      */
     final class Quoter extends \Cycle\Database\Driver\Quoter
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\ReadonlyHandler instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\ReadonlyHandler instead.
      */
     final class ReadonlyHandler extends \Cycle\Database\Driver\ReadonlyHandler
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\Statement instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\Statement instead.
      */
     final class Statement extends \Cycle\Database\Driver\Statement
     {
@@ -492,21 +499,21 @@ namespace Spiral\Database\Driver {
 namespace Spiral\Database\Driver\MySQL {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\MySQL\MySQLCompiler instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\MySQL\MySQLCompiler instead.
      */
     class MySQLCompiler extends \Cycle\Database\Driver\MySQL\MySQLCompiler
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\MySQL\MySQLDriver instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\MySQL\MySQLDriver instead.
      */
     class MySQLDriver extends \Cycle\Database\Driver\MySQL\MySQLDriver
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\MySQL\MySQLHandler instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\MySQL\MySQLHandler instead.
      */
     class MySQLHandler extends \Cycle\Database\Driver\MySQL\MySQLHandler
     {
@@ -516,7 +523,7 @@ namespace Spiral\Database\Driver\MySQL {
 namespace Spiral\Database\Driver\MySQL\Exception {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\MySQL\Exception\MySQLException instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\MySQL\Exception\MySQLException instead.
      */
     class MySQLException extends \Cycle\Database\Driver\MySQL\Exception\MySQLException
     {
@@ -526,28 +533,28 @@ namespace Spiral\Database\Driver\MySQL\Exception {
 namespace Spiral\Database\Driver\MySQL\Schema {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\MySQL\Schema\MySQLColumn instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\MySQL\Schema\MySQLColumn instead.
      */
     class MySQLColumn extends \Cycle\Database\Driver\MySQL\Schema\MySQLColumn
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\MySQL\Schema\MySQLForeignKey instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\MySQL\Schema\MySQLForeignKey instead.
      */
     class MySQLForeignKey extends \Cycle\Database\Driver\MySQL\Schema\MySQLForeignKey
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\MySQL\Schema\MySQLIndex instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\MySQL\Schema\MySQLIndex instead.
      */
     class MySQLIndex extends \Cycle\Database\Driver\MySQL\Schema\MySQLIndex
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\MySQL\Schema\MySQLTable instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\MySQL\Schema\MySQLTable instead.
      */
     class MySQLTable extends \Cycle\Database\Driver\MySQL\Schema\MySQLTable
     {
@@ -557,21 +564,21 @@ namespace Spiral\Database\Driver\MySQL\Schema {
 namespace Spiral\Database\Driver\Postgres {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\Postgres\PostgresCompiler instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\Postgres\PostgresCompiler instead.
      */
     class PostgresCompiler extends \Cycle\Database\Driver\Postgres\PostgresCompiler
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\Postgres\PostgresDriver instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\Postgres\PostgresDriver instead.
      */
     class PostgresDriver extends \Cycle\Database\Driver\Postgres\PostgresDriver
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\Postgres\PostgresHandler instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\Postgres\PostgresHandler instead.
      */
     class PostgresHandler extends \Cycle\Database\Driver\Postgres\PostgresHandler
     {
@@ -581,14 +588,14 @@ namespace Spiral\Database\Driver\Postgres {
 namespace Spiral\Database\Driver\Postgres\Query {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\Postgres\Query\PostgresInsertQuery instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\Postgres\Query\PostgresInsertQuery instead.
      */
     class PostgresInsertQuery extends \Cycle\Database\Driver\Postgres\Query\PostgresInsertQuery
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\Postgres\Query\PostgresSelectQuery instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\Postgres\Query\PostgresSelectQuery instead.
      */
     class PostgresSelectQuery extends \Cycle\Database\Driver\Postgres\Query\PostgresSelectQuery
     {
@@ -598,28 +605,28 @@ namespace Spiral\Database\Driver\Postgres\Query {
 namespace Spiral\Database\Driver\Postgres\Schema {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\Postgres\Schema\PostgresColumn instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\Postgres\Schema\PostgresColumn instead.
      */
     class PostgresColumn extends \Cycle\Database\Driver\Postgres\Schema\PostgresColumn
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\Postgres\Schema\PostgresForeignKey instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\Postgres\Schema\PostgresForeignKey instead.
      */
     class PostgresForeignKey extends \Cycle\Database\Driver\Postgres\Schema\PostgresForeignKey
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\Postgres\Schema\PostgresIndex instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\Postgres\Schema\PostgresIndex instead.
      */
     class PostgresIndex extends \Cycle\Database\Driver\Postgres\Schema\PostgresIndex
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\Postgres\Schema\PostgresTable instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\Postgres\Schema\PostgresTable instead.
      */
     class PostgresTable extends \Cycle\Database\Driver\Postgres\Schema\PostgresTable
     {
@@ -629,21 +636,21 @@ namespace Spiral\Database\Driver\Postgres\Schema {
 namespace Spiral\Database\Driver\SQLite {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\SQLite\SQLiteCompiler instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\SQLite\SQLiteCompiler instead.
      */
     class SQLiteCompiler extends \Cycle\Database\Driver\SQLite\SQLiteCompiler
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\SQLite\SQLiteDriver instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\SQLite\SQLiteDriver instead.
      */
     class SQLiteDriver extends \Cycle\Database\Driver\SQLite\SQLiteDriver
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\SQLite\SQLiteHandler instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\SQLite\SQLiteHandler instead.
      */
     class SQLiteHandler extends \Cycle\Database\Driver\SQLite\SQLiteHandler
     {
@@ -653,28 +660,28 @@ namespace Spiral\Database\Driver\SQLite {
 namespace Spiral\Database\Driver\SQLite\Schema {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\SQLite\Schema\SQLiteColumn instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\SQLite\Schema\SQLiteColumn instead.
      */
     class SQLiteColumn extends \Cycle\Database\Driver\SQLite\Schema\SQLiteColumn
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\SQLite\Schema\SQLiteForeignKey instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\SQLite\Schema\SQLiteForeignKey instead.
      */
     class SQLiteForeignKey extends \Cycle\Database\Driver\SQLite\Schema\SQLiteForeignKey
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\SQLite\Schema\SQLiteIndex instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\SQLite\Schema\SQLiteIndex instead.
      */
     class SQLiteIndex extends \Cycle\Database\Driver\SQLite\Schema\SQLiteIndex
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\SQLite\Schema\SQLiteTable instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\SQLite\Schema\SQLiteTable instead.
      */
     class SQLiteTable extends \Cycle\Database\Driver\SQLite\Schema\SQLiteTable
     {
@@ -684,21 +691,21 @@ namespace Spiral\Database\Driver\SQLite\Schema {
 namespace Spiral\Database\Driver\SQLServer {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\SQLServer\SQLServerCompiler instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\SQLServer\SQLServerCompiler instead.
      */
     class SQLServerCompiler extends \Cycle\Database\Driver\SQLServer\SQLServerCompiler
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\SQLServer\SQLServerDriver instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\SQLServer\SQLServerDriver instead.
      */
     class SQLServerDriver extends \Cycle\Database\Driver\SQLServer\SQLServerDriver
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\SQLServer\SQLServerHandler instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\SQLServer\SQLServerHandler instead.
      */
     class SQLServerHandler extends \Cycle\Database\Driver\SQLServer\SQLServerHandler
     {
@@ -708,28 +715,28 @@ namespace Spiral\Database\Driver\SQLServer {
 namespace Spiral\Database\Driver\SQLServer\Schema {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\SQLServer\Schema\SQLServerColumn instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\SQLServer\Schema\SQLServerColumn instead.
      */
     class SQLServerColumn extends \Cycle\Database\Driver\SQLServer\Schema\SQLServerColumn
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\SQLServer\Schema\SQLServerForeignKey instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\SQLServer\Schema\SQLServerForeignKey instead.
      */
     class SQlServerForeignKey extends \Cycle\Database\Driver\SQLServer\Schema\SQLServerForeignKey
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\SQLServer\Schema\SQLServerIndex instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\SQLServer\Schema\SQLServerIndex instead.
      */
     class SQLServerIndex extends \Cycle\Database\Driver\SQLServer\Schema\SQLServerIndex
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Driver\SQLServer\Schema\SQLServerTable instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Driver\SQLServer\Schema\SQLServerTable instead.
      */
     class SQLServerTable extends \Cycle\Database\Driver\SQLServer\Schema\SQLServerTable
     {
@@ -739,14 +746,14 @@ namespace Spiral\Database\Driver\SQLServer\Schema {
 namespace Spiral\Database\Config {
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Config\DatabaseConfig instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Config\DatabaseConfig instead.
      */
     final class DatabaseConfig extends \Cycle\Database\Config\DatabaseConfig
     {
     }
 
     /**
-     * @deprecated Since Cycle ORM 1.0, use Cycle\Database\Config\DatabasePartial instead.
+     * @deprecated since cycle/database 1.0, use Cycle\Database\Config\DatabasePartial instead.
      */
     final class DatabasePartial extends \Cycle\Database\Config\DatabasePartial
     {

--- a/src/Database.php
+++ b/src/Database.php
@@ -13,6 +13,7 @@ namespace Cycle\Database;
 
 use Spiral\Core\Container\InjectableInterface;
 use Cycle\Database\Driver\DriverInterface;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
 use Cycle\Database\Query\DeleteQuery;
 use Cycle\Database\Query\InsertQuery;
 use Cycle\Database\Query\SelectQuery;
@@ -46,11 +47,13 @@ final class Database implements DatabaseInterface, InjectableInterface
     private $readDriver;
 
     /**
-     * @param string               $name       Internal database name/id.
-     * @param string               $prefix     Default database table prefix, will be used for all
-     *                                         table identifiers.
-     * @param DriverInterface      $driver     Driver instance responsible for database connection.
-     * @param DriverInterface|null $readDriver Read-only driver connection.
+     * @param string $name Internal database name/id.
+     * @param string $prefix Default database table prefix, will be used for all
+     *        table identifiers.
+     * @param SpiralDriverInterface|DriverInterface $driver Driver instance responsible for database connection.
+     *        The signature of this argument will be changed to {@see DriverInterface} in future release.
+     * @param SpiralDriverInterface|DriverInterface|null $readDriver Read-only driver connection.
+     *        The signature of this argument will be changed to {@see DriverInterface} in future release.
      */
     public function __construct(
         string $name,

--- a/src/Database.php
+++ b/src/Database.php
@@ -20,6 +20,8 @@ use Cycle\Database\Query\SelectQuery;
 use Cycle\Database\Query\UpdateQuery;
 use Throwable;
 
+interface_exists(SpiralDriverInterface::class);
+
 /**
  * Database class is high level abstraction at top of Driver. Databases usually linked to real
  * database or logical portion of database (filtered by prefix).
@@ -50,16 +52,14 @@ final class Database implements DatabaseInterface, InjectableInterface
      * @param string $name Internal database name/id.
      * @param string $prefix Default database table prefix, will be used for all
      *        table identifiers.
-     * @param SpiralDriverInterface|DriverInterface $driver Driver instance responsible for database connection.
-     *        The signature of this argument will be changed to {@see DriverInterface} in future release.
-     * @param SpiralDriverInterface|DriverInterface|null $readDriver Read-only driver connection.
-     *        The signature of this argument will be changed to {@see DriverInterface} in future release.
+     * @param DriverInterface $driver
+     * @param DriverInterface|null $readDriver
      */
     public function __construct(
         string $name,
         string $prefix,
-        DriverInterface $driver,
-        DriverInterface $readDriver = null
+        SpiralDriverInterface $driver,
+        SpiralDriverInterface $readDriver = null
     ) {
         $this->name = $name;
         $this->prefix = $prefix;

--- a/src/DatabaseManager.php
+++ b/src/DatabaseManager.php
@@ -25,6 +25,16 @@ use Cycle\Database\Driver\DriverInterface;
 use Cycle\Database\Exception\DatabaseException;
 use Cycle\Database\Exception\DBALException;
 use Spiral\Logger\Traits\LoggerTrait;
+use Spiral\Database\Config\DatabasePartial as SpiralDatabasePartial;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
+use Spiral\Database\Database as SpiralDatabase;
+use Spiral\Database\DatabaseProviderInterface as SpiralDatabaseProviderInterface;
+
+interface_exists(SpiralDriverInterface::class);
+interface_exists(SpiralDatabaseProviderInterface::class);
+class_exists(SpiralDatabasePartial::class);
+class_exists(SpiralDatabase::class);
+class_exists(SpiralDatabaseConfig::class);
 
 /**
  * Automatic factory and configurator for Drivers and Databases.
@@ -87,7 +97,7 @@ use Spiral\Logger\Traits\LoggerTrait;
  * echo $manager->database('runtime')->select()->from('users')->count();
  */
 final class DatabaseManager implements
-    DatabaseProviderInterface,
+    SpiralDatabaseProviderInterface,
     Container\SingletonInterface,
     Container\InjectorInterface
 {
@@ -122,8 +132,7 @@ final class DatabaseManager implements
     }
 
     /**
-     * @param SpiralDatabaseConfig|DatabaseConfig $config The signature of this
-     *        argument will be changed to {@see DatabaseConfig} in future release.
+     * @param DatabaseConfig $config
      * @param FactoryInterface|null $factory
      */
     public function __construct(SpiralDatabaseConfig $config, FactoryInterface $factory = null)
@@ -205,7 +214,7 @@ final class DatabaseManager implements
      *
      * @throws DBALException
      */
-    public function addDatabase(Database $database): void
+    public function addDatabase(SpiralDatabase $database): void
     {
         if (isset($this->databases[$database->getName()])) {
             throw new DBALException("Database '{$database->getName()}' already exists");
@@ -278,7 +287,7 @@ final class DatabaseManager implements
      *
      * @throws DBALException
      */
-    public function addDriver(string $name, DriverInterface $driver): DatabaseManager
+    public function addDriver(string $name, SpiralDriverInterface $driver): DatabaseManager
     {
         if (isset($this->drivers[$name])) {
             throw new DBALException("Connection '{$name}' already exists");
@@ -295,7 +304,7 @@ final class DatabaseManager implements
      *
      * @throws DBALException
      */
-    protected function makeDatabase(DatabasePartial $database): Database
+    protected function makeDatabase(SpiralDatabasePartial $database): Database
     {
         return new Database(
             $database->getName(),

--- a/src/DatabaseManager.php
+++ b/src/DatabaseManager.php
@@ -18,6 +18,7 @@ use Psr\Log\NullLogger;
 use Spiral\Core\Container;
 use Spiral\Core\FactoryInterface;
 use Cycle\Database\Config\DatabaseConfig;
+use Spiral\Database\Config\DatabaseConfig as SpiralDatabaseConfig;
 use Cycle\Database\Config\DatabasePartial;
 use Cycle\Database\Driver\Driver;
 use Cycle\Database\Driver\DriverInterface;
@@ -121,10 +122,11 @@ final class DatabaseManager implements
     }
 
     /**
-     * @param DatabaseConfig   $config
-     * @param FactoryInterface $factory
+     * @param SpiralDatabaseConfig|DatabaseConfig $config The signature of this
+     *        argument will be changed to {@see DatabaseConfig} in future release.
+     * @param FactoryInterface|null $factory
      */
-    public function __construct(DatabaseConfig $config, FactoryInterface $factory = null)
+    public function __construct(SpiralDatabaseConfig $config, FactoryInterface $factory = null)
     {
         $this->config = $config;
         $this->factory = $factory ?? new Container();

--- a/src/Driver/CachingCompilerInterface.php
+++ b/src/Driver/CachingCompilerInterface.php
@@ -12,6 +12,9 @@ declare(strict_types=1);
 namespace Cycle\Database\Driver;
 
 use Cycle\Database\Query\QueryParameters;
+use Spiral\Database\Query\QueryParameters as SpiralQueryParameters;
+
+class_exists(SpiralQueryParameters::class);
 
 /**
  * Provides the ability to calculate query hash and generate cacheble statements.
@@ -25,5 +28,5 @@ interface CachingCompilerInterface extends CompilerInterface
      * @param array           $tokens
      * @return string
      */
-    public function hashLimit(QueryParameters $params, array $tokens): string;
+    public function hashLimit(SpiralQueryParameters $params, array $tokens): string;
 }

--- a/src/Driver/Compiler.php
+++ b/src/Driver/Compiler.php
@@ -16,6 +16,13 @@ use Cycle\Database\Injection\FragmentInterface;
 use Cycle\Database\Injection\Parameter;
 use Cycle\Database\Injection\ParameterInterface;
 use Cycle\Database\Query\QueryParameters;
+use Spiral\Database\Query\QueryParameters as SpiralQueryParameters;
+use Spiral\Database\Injection\FragmentInterface as SpiralFragmentInterface;
+use Spiral\Database\Driver\Quoter as SpiralQuoter;
+
+interface_exists(SpiralFragmentInterface::class);
+class_exists(SpiralQueryParameters::class);
+class_exists(SpiralQuoter::class);
 
 abstract class Compiler implements CompilerInterface
 {
@@ -48,9 +55,9 @@ abstract class Compiler implements CompilerInterface
      * @return string
      */
     public function compile(
-        QueryParameters $params,
+        SpiralQueryParameters $params,
         string $prefix,
-        FragmentInterface $fragment
+        SpiralFragmentInterface $fragment
     ): string {
         return $this->fragment(
             $params,
@@ -63,7 +70,7 @@ abstract class Compiler implements CompilerInterface
     /**
      * @inheritDoc
      */
-    public function hashLimit(QueryParameters $params, array $tokens): string
+    public function hashLimit(SpiralQueryParameters $params, array $tokens): string
     {
         if ($tokens['limit'] !== null) {
             $params->push(new Parameter($tokens['limit']));
@@ -84,9 +91,9 @@ abstract class Compiler implements CompilerInterface
      * @return string
      */
     protected function fragment(
-        QueryParameters $params,
-        Quoter $q,
-        FragmentInterface $fragment,
+        SpiralQueryParameters $params,
+        SpiralQuoter $q,
+        SpiralFragmentInterface $fragment,
         bool $nestedQuery = true
     ): string {
         $tokens = $fragment->getTokens();
@@ -147,7 +154,7 @@ abstract class Compiler implements CompilerInterface
      * @param array           $tokens
      * @return string
      */
-    protected function insertQuery(QueryParameters $params, Quoter $q, array $tokens): string
+    protected function insertQuery(SpiralQueryParameters $params, SpiralQuoter $q, array $tokens): string
     {
         $values = [];
         foreach ($tokens['values'] as $value) {
@@ -175,7 +182,7 @@ abstract class Compiler implements CompilerInterface
      * @param array           $tokens
      * @return string
      */
-    protected function selectQuery(QueryParameters $params, Quoter $q, array $tokens): string
+    protected function selectQuery(SpiralQueryParameters $params, SpiralQuoter $q, array $tokens): string
     {
         // This statement(s) parts should be processed first to define set of table and column aliases
         $tables = [];
@@ -207,7 +214,7 @@ abstract class Compiler implements CompilerInterface
      * @param bool|string     $distinct
      * @return string
      */
-    protected function distinct(QueryParameters $params, Quoter $q, $distinct): string
+    protected function distinct(SpiralQueryParameters $params, SpiralQuoter $q, $distinct): string
     {
         if ($distinct === false) {
             return '';
@@ -222,7 +229,7 @@ abstract class Compiler implements CompilerInterface
      * @param array           $joins
      * @return string
      */
-    protected function joins(QueryParameters $params, Quoter $q, array $joins): string
+    protected function joins(SpiralQueryParameters $params, SpiralQuoter $q, array $joins): string
     {
         $statement = '';
         foreach ($joins as $join) {
@@ -253,7 +260,7 @@ abstract class Compiler implements CompilerInterface
      * @param array           $unions
      * @return string
      */
-    protected function unions(QueryParameters $params, Quoter $q, array $unions): string
+    protected function unions(SpiralQueryParameters $params, SpiralQuoter $q, array $unions): string
     {
         if ($unions === []) {
             return '';
@@ -281,7 +288,7 @@ abstract class Compiler implements CompilerInterface
      * @param array           $orderBy
      * @return string
      */
-    protected function orderBy(QueryParameters $params, Quoter $q, array $orderBy): string
+    protected function orderBy(SpiralQueryParameters $params, SpiralQuoter $q, array $orderBy): string
     {
         $result = [];
         foreach ($orderBy as $order) {
@@ -305,7 +312,7 @@ abstract class Compiler implements CompilerInterface
      * @param array           $groupBy
      * @return string
      */
-    protected function groupBy(QueryParameters $params, Quoter $q, array $groupBy): string
+    protected function groupBy(SpiralQueryParameters $params, SpiralQuoter $q, array $groupBy): string
     {
         $result = [];
         foreach ($groupBy as $identifier) {
@@ -323,8 +330,8 @@ abstract class Compiler implements CompilerInterface
      * @return string
      */
     abstract protected function limit(
-        QueryParameters $params,
-        Quoter $q,
+        SpiralQueryParameters $params,
+        SpiralQuoter $q,
         int $limit = null,
         int $offset = null
     ): string;
@@ -336,8 +343,8 @@ abstract class Compiler implements CompilerInterface
      * @return string
      */
     protected function updateQuery(
-        QueryParameters $parameters,
-        Quoter $quoter,
+        SpiralQueryParameters $parameters,
+        SpiralQuoter $quoter,
         array $tokens
     ): string {
         $values = [];
@@ -364,8 +371,8 @@ abstract class Compiler implements CompilerInterface
      * @return string
      */
     protected function deleteQuery(
-        QueryParameters $parameters,
-        Quoter $quoter,
+        SpiralQueryParameters $parameters,
+        SpiralQuoter $quoter,
         array $tokens
     ): string {
         return sprintf(
@@ -385,7 +392,7 @@ abstract class Compiler implements CompilerInterface
      * @param bool            $table
      * @return string
      */
-    protected function name(QueryParameters $params, Quoter $q, $name, bool $table = false): string
+    protected function name(SpiralQueryParameters $params, SpiralQuoter $q, $name, bool $table = false): string
     {
         if ($name instanceof FragmentInterface) {
             return $this->fragment($params, $q, $name);
@@ -405,7 +412,7 @@ abstract class Compiler implements CompilerInterface
      * @param int             $maxLength
      * @return string
      */
-    protected function columns(QueryParameters $params, Quoter $q, array $columns, int $maxLength = 180): string
+    protected function columns(SpiralQueryParameters $params, SpiralQuoter $q, array $columns, int $maxLength = 180): string
     {
         // let's quote every identifier
         $columns = array_map(
@@ -424,7 +431,7 @@ abstract class Compiler implements CompilerInterface
      * @param mixed           $value
      * @return string
      */
-    protected function value(QueryParameters $params, Quoter $q, $value): string
+    protected function value(SpiralQueryParameters $params, SpiralQuoter $q, $value): string
     {
         if ($value instanceof FragmentInterface) {
             return $this->fragment($params, $q, $value);
@@ -456,7 +463,7 @@ abstract class Compiler implements CompilerInterface
      * @param array           $tokens
      * @return string
      */
-    protected function where(QueryParameters $params, Quoter $q, array $tokens): string
+    protected function where(SpiralQueryParameters $params, SpiralQuoter $q, array $tokens): string
     {
         if ($tokens === []) {
             return '';
@@ -522,7 +529,7 @@ abstract class Compiler implements CompilerInterface
      * @param array           $context
      * @return string
      */
-    protected function condition(QueryParameters $params, Quoter $q, array $context): string
+    protected function condition(SpiralQueryParameters $params, SpiralQuoter $q, array $context): string
     {
         $operator = $context[1];
         $value = $context[2];

--- a/src/Driver/CompilerCache.php
+++ b/src/Driver/CompilerCache.php
@@ -19,6 +19,7 @@ use Cycle\Database\Injection\ParameterInterface;
 use Cycle\Database\Query\QueryInterface;
 use Cycle\Database\Query\QueryParameters;
 use Cycle\Database\Query\SelectQuery;
+use Spiral\Database\Driver\CachingCompilerInterface as SpiralCachingCompilerInterface;
 
 /**
  * Caches calculated queries. Code in this class is performance optimized.
@@ -32,9 +33,10 @@ final class CompilerCache implements CompilerInterface
     private $compiler;
 
     /**
-     * @param CachingCompilerInterface $compiler
+     * @param SpiralCachingCompilerInterface|CachingCompilerInterface $compiler The signature
+     *        of this argument will be changed to {@see DriverInterface} in future release.
      */
-    public function __construct(CachingCompilerInterface $compiler)
+    public function __construct(SpiralCachingCompilerInterface $compiler)
     {
         $this->compiler = $compiler;
     }

--- a/src/Driver/CompilerCache.php
+++ b/src/Driver/CompilerCache.php
@@ -19,7 +19,15 @@ use Cycle\Database\Injection\ParameterInterface;
 use Cycle\Database\Query\QueryInterface;
 use Cycle\Database\Query\QueryParameters;
 use Cycle\Database\Query\SelectQuery;
+use Spiral\Database\Injection\FragmentInterface as SpiralFragmentInterface;
+use Spiral\Database\Injection\ParameterInterface as SpiralParameterInterface;
 use Spiral\Database\Driver\CachingCompilerInterface as SpiralCachingCompilerInterface;
+use Spiral\Database\Query\QueryParameters as SpiralQueryParameters;
+
+interface_exists(SpiralCachingCompilerInterface::class);
+interface_exists(SpiralFragmentInterface::class);
+interface_exists(SpiralParameterInterface::class);
+class_exists(SpiralQueryParameters::class);
 
 /**
  * Caches calculated queries. Code in this class is performance optimized.
@@ -33,8 +41,7 @@ final class CompilerCache implements CompilerInterface
     private $compiler;
 
     /**
-     * @param SpiralCachingCompilerInterface|CachingCompilerInterface $compiler The signature
-     *        of this argument will be changed to {@see DriverInterface} in future release.
+     * @param CachingCompilerInterface $compiler
      */
     public function __construct(SpiralCachingCompilerInterface $compiler)
     {
@@ -56,7 +63,7 @@ final class CompilerCache implements CompilerInterface
      * @param FragmentInterface $fragment
      * @return string
      */
-    public function compile(QueryParameters $params, string $prefix, FragmentInterface $fragment): string
+    public function compile(SpiralQueryParameters $params, string $prefix, SpiralFragmentInterface $fragment): string
     {
         if ($fragment->getType() === self::SELECT_QUERY) {
             $queryHash = $prefix . $this->hashSelectQuery($params, $fragment->getTokens());
@@ -101,7 +108,7 @@ final class CompilerCache implements CompilerInterface
      * @param array           $tokens
      * @return string
      */
-    protected function hashInsertQuery(QueryParameters $params, array $tokens): string
+    protected function hashInsertQuery(SpiralQueryParameters $params, array $tokens): string
     {
         $hash = 'i_' . $tokens['table'] . implode('_', $tokens['columns']) . '_r' . ($tokens['return'] ?? '');
         foreach ($tokens['values'] as $value) {
@@ -149,7 +156,7 @@ final class CompilerCache implements CompilerInterface
      * @param array           $tokens
      * @return string
      */
-    protected function hashSelectQuery(QueryParameters $params, array $tokens): string
+    protected function hashSelectQuery(SpiralQueryParameters $params, array $tokens): string
     {
         // stable part of hash
         if (is_array($tokens['distinct']) && isset($tokens['distinct']['on'])) {
@@ -218,7 +225,7 @@ final class CompilerCache implements CompilerInterface
      * @param array           $where
      * @return string
      */
-    protected function hashWhere(QueryParameters $params, array $where): string
+    protected function hashWhere(SpiralQueryParameters $params, array $where): string
     {
         $hash = '';
         foreach ($where as $condition) {
@@ -307,7 +314,7 @@ final class CompilerCache implements CompilerInterface
      * @param array           $columns
      * @return string
      */
-    protected function hashColumns(QueryParameters $params, array $columns): string
+    protected function hashColumns(SpiralQueryParameters $params, array $columns): string
     {
         $hash = '';
         foreach ($columns as $column) {

--- a/src/Driver/CompilerInterface.php
+++ b/src/Driver/CompilerInterface.php
@@ -13,6 +13,11 @@ namespace Cycle\Database\Driver;
 
 use Cycle\Database\Injection\FragmentInterface;
 use Cycle\Database\Query\QueryParameters;
+use Spiral\Database\Injection\FragmentInterface as SpiralFragmentInterface;
+use Spiral\Database\Query\QueryParameters as SpiralQueryParameters;
+
+interface_exists(SpiralFragmentInterface::class);
+class_exists(SpiralQueryParameters::class);
 
 interface CompilerInterface
 {
@@ -42,8 +47,8 @@ interface CompilerInterface
      * @return string
      */
     public function compile(
-        QueryParameters $params,
+        SpiralQueryParameters $params,
         string $prefix,
-        FragmentInterface $fragment
+        SpiralFragmentInterface $fragment
     ): string;
 }

--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -27,6 +27,9 @@ use Cycle\Database\Query\BuilderInterface;
 use Cycle\Database\Query\Interpolator;
 use Cycle\Database\StatementInterface;
 use Throwable;
+use Spiral\Database\Query\BuilderInterface as SpiralBuilderInterface;
+use Spiral\Database\Driver\HandlerInterface as SpiralHandlerInterface;
+use Spiral\Database\Driver\CompilerInterface as SpiralCompilerInterface;
 
 /**
  * Provides low level abstraction at top of
@@ -97,15 +100,18 @@ abstract class Driver implements DriverInterface, LoggerAwareInterface
 
     /**
      * @param array             $options
-     * @param HandlerInterface  $schemaHandler
-     * @param CompilerInterface $queryCompiler
-     * @param BuilderInterface  $queryBuilder
+     * @param SpiralHandlerInterface|HandlerInterface $schemaHandler The signature of
+     *        this argument will be changed to {@see HandlerInterface} in future release.
+     * @param SpiralCompilerInterface|CompilerInterface $queryCompiler The signature of
+     *        this argument will be changed to {@see CompilerInterface} in future release.
+     * @param SpiralBuilderInterface|BuilderInterface $queryBuilder The signature of
+     *        this argument will be changed to {@see BuilderInterface} in future release.
      */
     public function __construct(
         array $options,
-        HandlerInterface $schemaHandler,
-        CompilerInterface $queryCompiler,
-        BuilderInterface $queryBuilder
+        SpiralHandlerInterface $schemaHandler,
+        SpiralCompilerInterface $queryCompiler,
+        SpiralBuilderInterface $queryBuilder
     ) {
         $this->schemaHandler = $schemaHandler->withDriver($this);
         $this->queryBuilder = $queryBuilder->withDriver($this);

--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -31,6 +31,10 @@ use Spiral\Database\Query\BuilderInterface as SpiralBuilderInterface;
 use Spiral\Database\Driver\HandlerInterface as SpiralHandlerInterface;
 use Spiral\Database\Driver\CompilerInterface as SpiralCompilerInterface;
 
+interface_exists(SpiralBuilderInterface::class);
+interface_exists(SpiralHandlerInterface::class);
+interface_exists(SpiralCompilerInterface::class);
+
 /**
  * Provides low level abstraction at top of
  */
@@ -100,12 +104,9 @@ abstract class Driver implements DriverInterface, LoggerAwareInterface
 
     /**
      * @param array             $options
-     * @param SpiralHandlerInterface|HandlerInterface $schemaHandler The signature of
-     *        this argument will be changed to {@see HandlerInterface} in future release.
-     * @param SpiralCompilerInterface|CompilerInterface $queryCompiler The signature of
-     *        this argument will be changed to {@see CompilerInterface} in future release.
-     * @param SpiralBuilderInterface|BuilderInterface $queryBuilder The signature of
-     *        this argument will be changed to {@see BuilderInterface} in future release.
+     * @param HandlerInterface  $schemaHandler
+     * @param CompilerInterface $queryCompiler
+     * @param BuilderInterface  $queryBuilder
      */
     public function __construct(
         array $options,

--- a/src/Driver/HandlerInterface.php
+++ b/src/Driver/HandlerInterface.php
@@ -16,6 +16,17 @@ use Cycle\Database\Schema\AbstractColumn;
 use Cycle\Database\Schema\AbstractForeignKey;
 use Cycle\Database\Schema\AbstractIndex;
 use Cycle\Database\Schema\AbstractTable;
+use Spiral\Database\Schema\AbstractColumn as SpiralAbstractColumn;
+use Spiral\Database\Schema\AbstractIndex as SpiralAbstractIndex;
+use Spiral\Database\Schema\AbstractForeignKey as SpiralAbstractForeignKey;
+use Spiral\Database\Schema\AbstractTable as SpiralAbstractTable;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
+
+interface_exists(SpiralDriverInterface::class);
+class_exists(SpiralAbstractColumn::class);
+class_exists(SpiralAbstractIndex::class);
+class_exists(SpiralAbstractForeignKey::class);
+class_exists(SpiralAbstractTable::class);
 
 /**
  * Manages database schema.
@@ -57,7 +68,7 @@ interface HandlerInterface
      * @param DriverInterface $driver
      * @return HandlerInterface
      */
-    public function withDriver(DriverInterface $driver): HandlerInterface;
+    public function withDriver(SpiralDriverInterface $driver): HandlerInterface;
 
     /**
      * Get all available table names.
@@ -91,7 +102,7 @@ interface HandlerInterface
      * @param AbstractTable $table
      * @throws HandlerException
      */
-    public function createTable(AbstractTable $table): void;
+    public function createTable(SpiralAbstractTable $table): void;
 
     /**
      * Truncate table.
@@ -99,7 +110,7 @@ interface HandlerInterface
      * @param AbstractTable $table
      * @throws HandlerException
      */
-    public function eraseTable(AbstractTable $table): void;
+    public function eraseTable(SpiralAbstractTable $table): void;
 
     /**
      * Drop table from database.
@@ -107,15 +118,15 @@ interface HandlerInterface
      * @param AbstractTable $table
      * @throws HandlerException
      */
-    public function dropTable(AbstractTable $table): void;
+    public function dropTable(SpiralAbstractTable $table): void;
 
     /**
      * Sync given table schema.
      *
      * @param AbstractTable $table
-     * @param int           $operation See behaviour constants.
+     * @param int                               $operation See behaviour constants.
      */
-    public function syncTable(AbstractTable $table, int $operation = self::DO_ALL): void;
+    public function syncTable(SpiralAbstractTable $table, int $operation = self::DO_ALL): void;
 
     /**
      * Rename table from one name to another.
@@ -135,7 +146,7 @@ interface HandlerInterface
      *
      * @throws HandlerException
      */
-    public function createColumn(AbstractTable $table, AbstractColumn $column): void;
+    public function createColumn(SpiralAbstractTable $table, SpiralAbstractColumn $column): void;
 
     /**
      * Driver specific column remove (drop) command.
@@ -143,7 +154,7 @@ interface HandlerInterface
      * @param AbstractTable  $table
      * @param AbstractColumn $column
      */
-    public function dropColumn(AbstractTable $table, AbstractColumn $column): void;
+    public function dropColumn(SpiralAbstractTable $table, SpiralAbstractColumn $column): void;
 
     /**
      * Driver specific column alter command.
@@ -155,9 +166,9 @@ interface HandlerInterface
      * @throws HandlerException
      */
     public function alterColumn(
-        AbstractTable $table,
-        AbstractColumn $initial,
-        AbstractColumn $column
+        SpiralAbstractTable $table,
+        SpiralAbstractColumn $initial,
+        SpiralAbstractColumn $column
     ): void;
 
     /**
@@ -168,7 +179,7 @@ interface HandlerInterface
      *
      * @throws HandlerException
      */
-    public function createIndex(AbstractTable $table, AbstractIndex $index): void;
+    public function createIndex(SpiralAbstractTable $table, SpiralAbstractIndex $index): void;
 
     /**
      * Driver specific index remove (drop) command.
@@ -178,7 +189,7 @@ interface HandlerInterface
      *
      * @throws HandlerException
      */
-    public function dropIndex(AbstractTable $table, AbstractIndex $index): void;
+    public function dropIndex(SpiralAbstractTable $table, SpiralAbstractIndex $index): void;
 
     /**
      * Driver specific index alter command, by default it will remove and add index.
@@ -190,9 +201,9 @@ interface HandlerInterface
      * @throws HandlerException
      */
     public function alterIndex(
-        AbstractTable $table,
-        AbstractIndex $initial,
-        AbstractIndex $index
+        SpiralAbstractTable $table,
+        SpiralAbstractIndex $initial,
+        SpiralAbstractIndex $index
     ): void;
 
     /**
@@ -203,7 +214,7 @@ interface HandlerInterface
      *
      * @throws HandlerException
      */
-    public function createForeignKey(AbstractTable $table, AbstractForeignKey $foreignKey): void;
+    public function createForeignKey(SpiralAbstractTable $table, SpiralAbstractForeignKey $foreignKey): void;
 
     /**
      * Driver specific foreign key remove (drop) command.
@@ -213,7 +224,7 @@ interface HandlerInterface
      *
      * @throws HandlerException
      */
-    public function dropForeignKey(AbstractTable $table, AbstractForeignKey $foreignKey): void;
+    public function dropForeignKey(SpiralAbstractTable $table, SpiralAbstractForeignKey $foreignKey): void;
 
     /**
      * Driver specific foreign key alter command, by default it will remove and add foreign key.
@@ -225,9 +236,9 @@ interface HandlerInterface
      * @throws HandlerException
      */
     public function alterForeignKey(
-        AbstractTable $table,
-        AbstractForeignKey $initial,
-        AbstractForeignKey $foreignKey
+        SpiralAbstractTable $table,
+        SpiralAbstractForeignKey $initial,
+        SpiralAbstractForeignKey $foreignKey
     ): void;
 
     /**
@@ -238,5 +249,5 @@ interface HandlerInterface
      *
      * @throws HandlerException
      */
-    public function dropConstrain(AbstractTable $table, string $constraint): void;
+    public function dropConstrain(SpiralAbstractTable $table, string $constraint): void;
 }

--- a/src/Driver/MySQL/MySQLCompiler.php
+++ b/src/Driver/MySQL/MySQLCompiler.php
@@ -16,6 +16,11 @@ use Cycle\Database\Driver\Compiler;
 use Cycle\Database\Driver\Quoter;
 use Cycle\Database\Injection\Parameter;
 use Cycle\Database\Query\QueryParameters;
+use Spiral\Database\Query\QueryParameters as SpiralQueryParameters;
+use Spiral\Database\Driver\Quoter as SpiralQuoter;
+
+class_exists(SpiralQueryParameters::class);
+class_exists(SpiralQuoter::class);
 
 /**
  * MySQL syntax specific compiler.
@@ -28,7 +33,7 @@ class MySQLCompiler extends Compiler implements CachingCompilerInterface
      * @param array           $tokens
      * @return string
      */
-    protected function insertQuery(QueryParameters $params, Quoter $q, array $tokens): string
+    protected function insertQuery(SpiralQueryParameters $params, SpiralQuoter $q, array $tokens): string
     {
         if ($tokens['columns'] === []) {
             return sprintf(
@@ -45,7 +50,7 @@ class MySQLCompiler extends Compiler implements CachingCompilerInterface
      *
      * @link http://dev.mysql.com/doc/refman/5.0/en/select.html#id4651990
      */
-    protected function limit(QueryParameters $params, Quoter $q, int $limit = null, int $offset = null): string
+    protected function limit(SpiralQueryParameters $params, SpiralQuoter $q, int $limit = null, int $offset = null): string
     {
         if ($limit === null && $offset === null) {
             return '';

--- a/src/Driver/MySQL/MySQLHandler.php
+++ b/src/Driver/MySQL/MySQLHandler.php
@@ -17,9 +17,16 @@ use Cycle\Database\Driver\MySQL\Exception\MySQLException;
 use Cycle\Database\Driver\MySQL\Schema\MySQLTable;
 use Cycle\Database\Exception\SchemaException;
 use Cycle\Database\Schema\AbstractColumn;
-use Cycle\Database\Schema\AbstractForeignKey;
-use Cycle\Database\Schema\AbstractIndex;
 use Cycle\Database\Schema\AbstractTable;
+use Spiral\Database\Schema\AbstractColumn as SpiralAbstractColumn;
+use Spiral\Database\Schema\AbstractIndex as SpiralAbstractIndex;
+use Spiral\Database\Schema\AbstractForeignKey as SpiralAbstractForeignKey;
+use Spiral\Database\Schema\AbstractTable as SpiralAbstractTable;
+
+class_exists(SpiralAbstractColumn::class);
+class_exists(SpiralAbstractIndex::class);
+class_exists(SpiralAbstractForeignKey::class);
+class_exists(SpiralAbstractTable::class);
 
 class MySQLHandler extends Handler
 {
@@ -57,7 +64,7 @@ class MySQLHandler extends Handler
     /**
      * {@inheritdoc}
      */
-    public function eraseTable(AbstractTable $table): void
+    public function eraseTable(SpiralAbstractTable $table): void
     {
         $this->driver->execute(
             "TRUNCATE TABLE {$this->driver->identifier($table->getName())}"
@@ -68,9 +75,9 @@ class MySQLHandler extends Handler
      * {@inheritdoc}
      */
     public function alterColumn(
-        AbstractTable $table,
-        AbstractColumn $initial,
-        AbstractColumn $column
+        SpiralAbstractTable $table,
+        SpiralAbstractColumn $initial,
+        SpiralAbstractColumn $column
     ): void {
         $foreignBackup = [];
         foreach ($table->getForeignKeys() as $foreign) {
@@ -94,7 +101,7 @@ class MySQLHandler extends Handler
     /**
      * {@inheritdoc}
      */
-    public function dropIndex(AbstractTable $table, AbstractIndex $index): void
+    public function dropIndex(SpiralAbstractTable $table, SpiralAbstractIndex $index): void
     {
         $this->run(
             "DROP INDEX {$this->identify($index)} ON {$this->identify($table)}"
@@ -104,7 +111,7 @@ class MySQLHandler extends Handler
     /**
      * {@inheritdoc}
      */
-    public function alterIndex(AbstractTable $table, AbstractIndex $initial, AbstractIndex $index): void
+    public function alterIndex(SpiralAbstractTable $table, SpiralAbstractIndex $initial, SpiralAbstractIndex $index): void
     {
         $this->run(
             "ALTER TABLE {$this->identify($table)}
@@ -116,7 +123,7 @@ class MySQLHandler extends Handler
     /**
      * {@inheritdoc}
      */
-    public function dropForeignKey(AbstractTable $table, AbstractForeignKey $foreignKey): void
+    public function dropForeignKey(SpiralAbstractTable $table, SpiralAbstractForeignKey $foreignKey): void
     {
         $this->run(
             "ALTER TABLE {$this->identify($table)} DROP FOREIGN KEY {$this->identify($foreignKey)}"
@@ -131,7 +138,7 @@ class MySQLHandler extends Handler
      *
      * @throws SchemaException
      */
-    protected function createStatement(AbstractTable $table)
+    protected function createStatement(SpiralAbstractTable $table)
     {
         if (!$table instanceof MySQLTable) {
             throw new SchemaException('MySQLHandler can process only MySQL tables');
@@ -145,7 +152,7 @@ class MySQLHandler extends Handler
      *
      * @throws MySQLException
      */
-    protected function assertValid(AbstractColumn $column): void
+    protected function assertValid(SpiralAbstractColumn $column): void
     {
         if (
             $column->getDefaultValue() !== null

--- a/src/Driver/MySQL/Schema/MySQLColumn.php
+++ b/src/Driver/MySQL/Schema/MySQLColumn.php
@@ -11,11 +11,13 @@ declare(strict_types=1);
 
 namespace Cycle\Database\Driver\MySQL\Schema;
 
-use Cycle\Database\Driver\DriverInterface;
 use Cycle\Database\Exception\DefaultValueException;
 use Cycle\Database\Injection\Fragment;
 use Cycle\Database\Injection\FragmentInterface;
 use Cycle\Database\Schema\AbstractColumn;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
+
+interface_exists(SpiralDriverInterface::class);
 
 /**
  * Attention! You can use only one timestamp or datetime with DATETIME_NOW setting! Thought, it will
@@ -141,7 +143,7 @@ class MySQLColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    public function sqlStatement(DriverInterface $driver): string
+    public function sqlStatement(SpiralDriverInterface $driver): string
     {
         $defaultValue = $this->defaultValue;
 

--- a/src/Driver/MySQL/Schema/MySQLTable.php
+++ b/src/Driver/MySQL/Schema/MySQLTable.php
@@ -17,6 +17,9 @@ use Cycle\Database\Schema\AbstractForeignKey;
 use Cycle\Database\Schema\AbstractIndex;
 use Cycle\Database\Schema\AbstractTable;
 use Cycle\Database\Schema\State;
+use Spiral\Database\Schema\State as SpiralState;
+
+class_exists(SpiralState::class);
 
 class MySQLTable extends AbstractTable
 {
@@ -73,7 +76,7 @@ class MySQLTable extends AbstractTable
      *
      * @param State $state
      */
-    protected function initSchema(State $state): void
+    protected function initSchema(SpiralState $state): void
     {
         parent::initSchema($state);
 

--- a/src/Driver/Postgres/PostgresCompiler.php
+++ b/src/Driver/Postgres/PostgresCompiler.php
@@ -16,6 +16,11 @@ use Cycle\Database\Driver\Compiler;
 use Cycle\Database\Driver\Quoter;
 use Cycle\Database\Injection\Parameter;
 use Cycle\Database\Query\QueryParameters;
+use Spiral\Database\Query\QueryParameters as SpiralQueryParameters;
+use Spiral\Database\Driver\Quoter as SpiralQuoter;
+
+class_exists(SpiralQueryParameters::class);
+class_exists(SpiralQuoter::class);
 
 /**
  * Postgres syntax specific compiler.
@@ -28,7 +33,7 @@ class PostgresCompiler extends Compiler implements CachingCompilerInterface
      * @param array           $tokens
      * @return string
      */
-    protected function insertQuery(QueryParameters $params, Quoter $q, array $tokens): string
+    protected function insertQuery(SpiralQueryParameters $params, SpiralQuoter $q, array $tokens): string
     {
         $result = parent::insertQuery($params, $q, $tokens);
 
@@ -46,7 +51,7 @@ class PostgresCompiler extends Compiler implements CachingCompilerInterface
     /**
      * {@inheritdoc}
      */
-    protected function distinct(QueryParameters $params, Quoter $q, $distinct): string
+    protected function distinct(SpiralQueryParameters $params, SpiralQuoter $q, $distinct): string
     {
         if ($distinct === false) {
             return '';
@@ -70,7 +75,7 @@ class PostgresCompiler extends Compiler implements CachingCompilerInterface
      * @param int|null        $offset
      * @return string
      */
-    protected function limit(QueryParameters $params, Quoter $q, int $limit = null, int $offset = null): string
+    protected function limit(SpiralQueryParameters $params, SpiralQuoter $q, int $limit = null, int $offset = null): string
     {
         if ($limit === null && $offset === null) {
             return '';

--- a/src/Driver/Postgres/PostgresHandler.php
+++ b/src/Driver/Postgres/PostgresHandler.php
@@ -17,6 +17,11 @@ use Cycle\Database\Driver\Postgres\Schema\PostgresTable;
 use Cycle\Database\Exception\SchemaException;
 use Cycle\Database\Schema\AbstractColumn;
 use Cycle\Database\Schema\AbstractTable;
+use Spiral\Database\Schema\AbstractColumn as SpiralAbstractColumn;
+use Spiral\Database\Schema\AbstractTable as SpiralAbstractTable;
+
+class_exists(SpiralAbstractColumn::class);
+class_exists(SpiralAbstractTable::class);
 
 class PostgresHandler extends Handler
 {
@@ -59,7 +64,7 @@ class PostgresHandler extends Handler
     /**
      * {@inheritdoc}
      */
-    public function eraseTable(AbstractTable $table): void
+    public function eraseTable(SpiralAbstractTable $table): void
     {
         $this->driver->execute(
             "TRUNCATE TABLE {$this->driver->identifier($table->getName())}"
@@ -72,9 +77,9 @@ class PostgresHandler extends Handler
      * @throws SchemaException
      */
     public function alterColumn(
-        AbstractTable $table,
-        AbstractColumn $initial,
-        AbstractColumn $column
+        SpiralAbstractTable $table,
+        SpiralAbstractColumn $initial,
+        SpiralAbstractColumn $column
     ): void {
         if (!$initial instanceof PostgresColumn || !$column instanceof PostgresColumn) {
             throw new SchemaException('Postgres handler can work only with Postgres columns');

--- a/src/Driver/Postgres/Query/PostgresInsertQuery.php
+++ b/src/Driver/Postgres/Query/PostgresInsertQuery.php
@@ -19,6 +19,9 @@ use Cycle\Database\Query\InsertQuery;
 use Cycle\Database\Query\QueryInterface;
 use Cycle\Database\Query\QueryParameters;
 use Throwable;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
+
+interface_exists(SpiralDriverInterface::class);
 
 /**
  * Postgres driver requires little bit different way to handle last insert id.
@@ -36,7 +39,7 @@ class PostgresInsertQuery extends InsertQuery
      * @param string|null     $prefix
      * @return QueryInterface
      */
-    public function withDriver(DriverInterface $driver, string $prefix = null): QueryInterface
+    public function withDriver(SpiralDriverInterface $driver, string $prefix = null): QueryInterface
     {
         if (!$driver instanceof PostgresDriver) {
             throw new BuilderException(

--- a/src/Driver/Postgres/Schema/PostgresColumn.php
+++ b/src/Driver/Postgres/Schema/PostgresColumn.php
@@ -14,6 +14,11 @@ namespace Cycle\Database\Driver\Postgres\Schema;
 use Cycle\Database\Driver\DriverInterface;
 use Cycle\Database\Injection\Fragment;
 use Cycle\Database\Schema\AbstractColumn;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
+use Spiral\Database\Schema\AbstractColumn as SpiralAbstractColumn;
+
+interface_exists(SpiralDriverInterface::class);
+class_exists(SpiralAbstractColumn::class);
 
 class PostgresColumn extends AbstractColumn
 {
@@ -205,7 +210,7 @@ class PostgresColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    public function sqlStatement(DriverInterface $driver): string
+    public function sqlStatement(SpiralDriverInterface $driver): string
     {
         $statement = parent::sqlStatement($driver);
 
@@ -234,7 +239,7 @@ class PostgresColumn extends AbstractColumn
      * @param AbstractColumn  $initial
      * @return array
      */
-    public function alterOperations(DriverInterface $driver, AbstractColumn $initial): array
+    public function alterOperations(SpiralDriverInterface $driver, SpiralAbstractColumn $initial): array
     {
         $operations = [];
 
@@ -312,7 +317,7 @@ class PostgresColumn extends AbstractColumn
     public static function createInstance(
         string $table,
         array $schema,
-        DriverInterface $driver
+        SpiralDriverInterface $driver
     ): self {
         $column = new self($table, $schema['column_name'], $driver->getTimezone());
 
@@ -365,7 +370,7 @@ class PostgresColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    public function compare(AbstractColumn $initial): bool
+    public function compare(SpiralAbstractColumn $initial): bool
     {
         if (parent::compare($initial)) {
             return true;
@@ -385,7 +390,7 @@ class PostgresColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    protected function quoteEnum(DriverInterface $driver): string
+    protected function quoteEnum(SpiralDriverInterface $driver): string
     {
         //Postgres enums are just constrained strings
         return '(' . $this->size . ')';

--- a/src/Driver/ReadonlyHandler.php
+++ b/src/Driver/ReadonlyHandler.php
@@ -11,11 +11,20 @@ declare(strict_types=1);
 
 namespace Cycle\Database\Driver;
 
-use Cycle\Database\Schema\AbstractColumn;
-use Cycle\Database\Schema\AbstractForeignKey;
-use Cycle\Database\Schema\AbstractIndex;
 use Cycle\Database\Schema\AbstractTable;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
 use Spiral\Database\Driver\HandlerInterface as SpiralHandlerInterface;
+use Spiral\Database\Schema\AbstractForeignKey as SpiralAbstractForeignKey;
+use Spiral\Database\Schema\AbstractColumn as SpiralAbstractColumn;
+use Spiral\Database\Schema\AbstractIndex as SpiralAbstractIndex;
+use Spiral\Database\Schema\AbstractTable as SpiralAbstractTable;
+
+interface_exists(SpiralDriverInterface::class);
+interface_exists(SpiralHandlerInterface::class);
+class_exists(SpiralAbstractForeignKey::class);
+class_exists(SpiralAbstractColumn::class);
+class_exists(SpiralAbstractIndex::class);
+class_exists(SpiralAbstractTable::class);
 
 final class ReadonlyHandler implements HandlerInterface
 {
@@ -23,8 +32,7 @@ final class ReadonlyHandler implements HandlerInterface
     private $parent;
 
     /**
-     * @param SpiralHandlerInterface|HandlerInterface $parent The signature of this
-     *        argument will be changed to {@see HandlerInterface} in future release.
+     * @param HandlerInterface $parent
      */
     public function __construct(SpiralHandlerInterface $parent)
     {
@@ -34,7 +42,7 @@ final class ReadonlyHandler implements HandlerInterface
     /**
      * @inheritDoc
      */
-    public function withDriver(DriverInterface $driver): HandlerInterface
+    public function withDriver(SpiralDriverInterface $driver): HandlerInterface
     {
         $handler = clone $this;
         $handler->parent = $handler->parent->withDriver($driver);
@@ -69,14 +77,14 @@ final class ReadonlyHandler implements HandlerInterface
     /**
      * @inheritDoc
      */
-    public function createTable(AbstractTable $table): void
+    public function createTable(SpiralAbstractTable $table): void
     {
     }
 
     /**
      * @inheritDoc
      */
-    public function eraseTable(AbstractTable $table): void
+    public function eraseTable(SpiralAbstractTable $table): void
     {
         $this->parent->eraseTable($table);
     }
@@ -84,14 +92,14 @@ final class ReadonlyHandler implements HandlerInterface
     /**
      * @inheritDoc
      */
-    public function dropTable(AbstractTable $table): void
+    public function dropTable(SpiralAbstractTable $table): void
     {
     }
 
     /**
      * @inheritDoc
      */
-    public function syncTable(AbstractTable $table, int $operation = self::DO_ALL): void
+    public function syncTable(SpiralAbstractTable $table, int $operation = self::DO_ALL): void
     {
     }
 
@@ -105,56 +113,56 @@ final class ReadonlyHandler implements HandlerInterface
     /**
      * @inheritDoc
      */
-    public function createColumn(AbstractTable $table, AbstractColumn $column): void
+    public function createColumn(SpiralAbstractTable $table, SpiralAbstractColumn $column): void
     {
     }
 
     /**
      * @inheritDoc
      */
-    public function dropColumn(AbstractTable $table, AbstractColumn $column): void
+    public function dropColumn(SpiralAbstractTable $table, SpiralAbstractColumn $column): void
     {
     }
 
     /**
      * @inheritDoc
      */
-    public function alterColumn(AbstractTable $table, AbstractColumn $initial, AbstractColumn $column): void
+    public function alterColumn(SpiralAbstractTable $table, SpiralAbstractColumn $initial, SpiralAbstractColumn $column): void
     {
     }
 
     /**
      * @inheritDoc
      */
-    public function createIndex(AbstractTable $table, AbstractIndex $index): void
+    public function createIndex(SpiralAbstractTable $table, SpiralAbstractIndex $index): void
     {
     }
 
     /**
      * @inheritDoc
      */
-    public function dropIndex(AbstractTable $table, AbstractIndex $index): void
+    public function dropIndex(SpiralAbstractTable $table, SpiralAbstractIndex $index): void
     {
     }
 
     /**
      * @inheritDoc
      */
-    public function alterIndex(AbstractTable $table, AbstractIndex $initial, AbstractIndex $index): void
+    public function alterIndex(SpiralAbstractTable $table, SpiralAbstractIndex $initial, SpiralAbstractIndex $index): void
     {
     }
 
     /**
      * @inheritDoc
      */
-    public function createForeignKey(AbstractTable $table, AbstractForeignKey $foreignKey): void
+    public function createForeignKey(SpiralAbstractTable $table, SpiralAbstractForeignKey $foreignKey): void
     {
     }
 
     /**
      * @inheritDoc
      */
-    public function dropForeignKey(AbstractTable $table, AbstractForeignKey $foreignKey): void
+    public function dropForeignKey(SpiralAbstractTable $table, SpiralAbstractForeignKey $foreignKey): void
     {
     }
 
@@ -162,16 +170,16 @@ final class ReadonlyHandler implements HandlerInterface
      * @inheritDoc
      */
     public function alterForeignKey(
-        AbstractTable $table,
-        AbstractForeignKey $initial,
-        AbstractForeignKey $foreignKey
+        SpiralAbstractTable $table,
+        SpiralAbstractForeignKey $initial,
+        SpiralAbstractForeignKey $foreignKey
     ): void {
     }
 
     /**
      * @inheritDoc
      */
-    public function dropConstrain(AbstractTable $table, string $constraint): void
+    public function dropConstrain(SpiralAbstractTable $table, string $constraint): void
     {
     }
 }

--- a/src/Driver/ReadonlyHandler.php
+++ b/src/Driver/ReadonlyHandler.php
@@ -15,6 +15,7 @@ use Cycle\Database\Schema\AbstractColumn;
 use Cycle\Database\Schema\AbstractForeignKey;
 use Cycle\Database\Schema\AbstractIndex;
 use Cycle\Database\Schema\AbstractTable;
+use Spiral\Database\Driver\HandlerInterface as SpiralHandlerInterface;
 
 final class ReadonlyHandler implements HandlerInterface
 {
@@ -22,9 +23,10 @@ final class ReadonlyHandler implements HandlerInterface
     private $parent;
 
     /**
-     * @param HandlerInterface $parent
+     * @param SpiralHandlerInterface|HandlerInterface $parent The signature of this
+     *        argument will be changed to {@see HandlerInterface} in future release.
      */
-    public function __construct(HandlerInterface $parent)
+    public function __construct(SpiralHandlerInterface $parent)
     {
         $this->parent = $parent;
     }

--- a/src/Driver/SQLServer/SQLServerCompiler.php
+++ b/src/Driver/SQLServer/SQLServerCompiler.php
@@ -16,6 +16,11 @@ use Cycle\Database\Driver\Quoter;
 use Cycle\Database\Injection\Fragment;
 use Cycle\Database\Injection\Parameter;
 use Cycle\Database\Query\QueryParameters;
+use Spiral\Database\Driver\Quoter as SpiralQuoter;
+use Spiral\Database\Query\QueryParameters as SpiralQueryParameters;
+
+class_exists(SpiralQuoter::class);
+class_exists(SpiralQueryParameters::class);
 
 /**
  * Microsoft SQL server specific syntax compiler.
@@ -37,7 +42,7 @@ class SQLServerCompiler extends Compiler
      * @link http://stackoverflow.com/questions/603724/how-to-implement-limit-with-microsoft-sql-server
      * @link http://stackoverflow.com/questions/971964/limit-10-20-in-sql-server
      */
-    protected function selectQuery(QueryParameters $params, Quoter $q, array $tokens): string
+    protected function selectQuery(SpiralQueryParameters $params, SpiralQuoter $q, array $tokens): string
     {
         $limit = $tokens['limit'];
         $offset = $tokens['offset'];
@@ -79,8 +84,8 @@ class SQLServerCompiler extends Compiler
      * @link http://stackoverflow.com/questions/2135418/equivalent-of-limit-and-offset-for-sql-server
      */
     protected function limit(
-        QueryParameters $params,
-        Quoter $q,
+        SpiralQueryParameters $params,
+        SpiralQuoter $q,
         int $limit = null,
         int $offset = null,
         string $rowNumber = null

--- a/src/Driver/SQLServer/SQLServerHandler.php
+++ b/src/Driver/SQLServer/SQLServerHandler.php
@@ -17,8 +17,14 @@ use Cycle\Database\Driver\SQLServer\Schema\SQLServerColumn;
 use Cycle\Database\Driver\SQLServer\Schema\SQLServerTable;
 use Cycle\Database\Exception\SchemaException;
 use Cycle\Database\Schema\AbstractColumn;
-use Cycle\Database\Schema\AbstractIndex;
 use Cycle\Database\Schema\AbstractTable;
+use Spiral\Database\Schema\AbstractColumn as SpiralAbstractColumn;
+use Spiral\Database\Schema\AbstractIndex as SpiralAbstractIndex;
+use Spiral\Database\Schema\AbstractTable as SpiralAbstractTable;
+
+class_exists(SpiralAbstractColumn::class);
+class_exists(SpiralAbstractIndex::class);
+class_exists(SpiralAbstractTable::class);
 
 class SQLServerHandler extends Handler
 {
@@ -59,7 +65,7 @@ class SQLServerHandler extends Handler
     /**
      * {@inheritdoc}
      */
-    public function eraseTable(AbstractTable $table): void
+    public function eraseTable(SpiralAbstractTable $table): void
     {
         $this->driver->execute(
             "TRUNCATE TABLE {$this->driver->identifier($table->getName())}"
@@ -80,7 +86,7 @@ class SQLServerHandler extends Handler
     /**
      * {@inheritdoc}
      */
-    public function createColumn(AbstractTable $table, AbstractColumn $column): void
+    public function createColumn(SpiralAbstractTable $table, SpiralAbstractColumn $column): void
     {
         $this->run(
             "ALTER TABLE {$this->identify($table)} ADD {$column->sqlStatement($this->driver)}"
@@ -97,9 +103,9 @@ class SQLServerHandler extends Handler
      * @throws SchemaException
      */
     public function alterColumn(
-        AbstractTable $table,
-        AbstractColumn $initial,
-        AbstractColumn $column
+        SpiralAbstractTable $table,
+        SpiralAbstractColumn $initial,
+        SpiralAbstractColumn $column
     ): void {
         if (!$initial instanceof SQLServerColumn || !$column instanceof SQLServerColumn) {
             throw new SchemaException('SQlServer handler can work only with SQLServer columns');
@@ -154,7 +160,7 @@ class SQLServerHandler extends Handler
     /**
      * {@inheritdoc}
      */
-    public function dropIndex(AbstractTable $table, AbstractIndex $index): void
+    public function dropIndex(SpiralAbstractTable $table, SpiralAbstractIndex $index): void
     {
         $this->run("DROP INDEX {$this->identify($index)} ON {$this->identify($table)}");
     }

--- a/src/Driver/SQLServer/Schema/SQLServerColumn.php
+++ b/src/Driver/SQLServer/Schema/SQLServerColumn.php
@@ -13,6 +13,11 @@ namespace Cycle\Database\Driver\SQLServer\Schema;
 
 use Cycle\Database\Driver\DriverInterface;
 use Cycle\Database\Schema\AbstractColumn;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
+use Spiral\Database\Schema\AbstractColumn as SpiralAbstractColumn;
+
+interface_exists(SpiralDriverInterface::class);
+class_exists(SpiralAbstractColumn::class);
 
 class SQLServerColumn extends AbstractColumn
 {
@@ -194,7 +199,7 @@ class SQLServerColumn extends AbstractColumn
      * @param bool $withEnum When true enum constrain will be included into definition. Set to false
      *                       if you want to create constrain separately.
      */
-    public function sqlStatement(DriverInterface $driver, bool $withEnum = true): string
+    public function sqlStatement(SpiralDriverInterface $driver, bool $withEnum = true): string
     {
         if ($withEnum && $this->getAbstractType() === 'enum') {
             return "{$this->sqlStatement($driver, false)} {$this->enumStatement($driver)}";
@@ -231,7 +236,7 @@ class SQLServerColumn extends AbstractColumn
      * @param AbstractColumn  $initial
      * @return array
      */
-    public function alterOperations(DriverInterface $driver, AbstractColumn $initial): array
+    public function alterOperations(SpiralDriverInterface $driver, SpiralAbstractColumn $initial): array
     {
         $operations = [];
 
@@ -301,7 +306,7 @@ class SQLServerColumn extends AbstractColumn
     public static function createInstance(
         string $table,
         array $schema,
-        DriverInterface $driver
+        SpiralDriverInterface $driver
     ): self {
         $column = new self($table, $schema['COLUMN_NAME'], $driver->getTimezone());
 
@@ -354,7 +359,7 @@ class SQLServerColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    protected function quoteDefault(DriverInterface $driver): string
+    protected function quoteDefault(SpiralDriverInterface $driver): string
     {
         $defaultValue = parent::quoteDefault($driver);
         if ($this->getAbstractType() === 'boolean') {

--- a/src/Driver/SQLite/SQLiteCompiler.php
+++ b/src/Driver/SQLite/SQLiteCompiler.php
@@ -13,11 +13,14 @@ namespace Cycle\Database\Driver\SQLite;
 
 use Cycle\Database\Driver\CachingCompilerInterface;
 use Cycle\Database\Driver\Compiler;
-use Cycle\Database\Driver\Quoter;
 use Cycle\Database\Exception\CompilerException;
 use Cycle\Database\Injection\Parameter;
 use Cycle\Database\Injection\ParameterInterface;
-use Cycle\Database\Query\QueryParameters;
+use Spiral\Database\Query\QueryParameters as SpiralQueryParameters;
+use Spiral\Database\Driver\Quoter as SpiralQuoter;
+
+class_exists(SpiralQueryParameters::class);
+class_exists(SpiralQuoter::class);
 
 class SQLiteCompiler extends Compiler implements CachingCompilerInterface
 {
@@ -26,7 +29,7 @@ class SQLiteCompiler extends Compiler implements CachingCompilerInterface
      *
      * @link http://stackoverflow.com/questions/10491492/sqllite-with-skip-offset-only-not-limit
      */
-    protected function limit(QueryParameters $params, Quoter $q, int $limit = null, int $offset = null): string
+    protected function limit(SpiralQueryParameters $params, SpiralQuoter $q, int $limit = null, int $offset = null): string
     {
         if ($limit === null && $offset === null) {
             return '';
@@ -50,7 +53,7 @@ class SQLiteCompiler extends Compiler implements CachingCompilerInterface
     /**
      * @inheritDoc
      */
-    protected function selectQuery(QueryParameters $params, Quoter $q, array $tokens): string
+    protected function selectQuery(SpiralQueryParameters $params, SpiralQuoter $q, array $tokens): string
     {
         // FOR UPDATE is not available
         $tokens['forUpdate'] = false;
@@ -63,7 +66,7 @@ class SQLiteCompiler extends Compiler implements CachingCompilerInterface
      *
      * @see http://stackoverflow.com/questions/1609637/is-it-possible-to-insert-multiple-rows-at-a-time-in-an-sqlite-database
      */
-    protected function insertQuery(QueryParameters $params, Quoter $q, array $tokens): string
+    protected function insertQuery(SpiralQueryParameters $params, SpiralQuoter $q, array $tokens): string
     {
         if ($tokens['columns'] === []) {
             return sprintf(

--- a/src/Driver/SQLite/SQLiteHandler.php
+++ b/src/Driver/SQLite/SQLiteHandler.php
@@ -15,9 +15,14 @@ use Cycle\Database\Driver\Handler;
 use Cycle\Database\Driver\SQLite\Schema\SQLiteTable;
 use Cycle\Database\Exception\DBALException;
 use Cycle\Database\Exception\HandlerException;
-use Cycle\Database\Schema\AbstractColumn;
-use Cycle\Database\Schema\AbstractForeignKey;
 use Cycle\Database\Schema\AbstractTable;
+use Spiral\Database\Schema\AbstractColumn as SpiralAbstractColumn;
+use Spiral\Database\Schema\AbstractForeignKey as SpiralAbstractForeignKey;
+use Spiral\Database\Schema\AbstractTable as SpiralAbstractTable;
+
+class_exists(SpiralAbstractColumn::class);
+class_exists(SpiralAbstractForeignKey::class);
+class_exists(SpiralAbstractTable::class);
 
 class SQLiteHandler extends Handler
 {
@@ -64,7 +69,7 @@ class SQLiteHandler extends Handler
     /**
      * @param AbstractTable $table
      */
-    public function eraseTable(AbstractTable $table): void
+    public function eraseTable(SpiralAbstractTable $table): void
     {
         $this->driver->execute(
             "DELETE FROM {$this->driver->identifier($table->getName())}"
@@ -74,7 +79,7 @@ class SQLiteHandler extends Handler
     /**
      * {@inheritdoc}
      */
-    public function syncTable(AbstractTable $table, int $operation = self::DO_ALL): void
+    public function syncTable(SpiralAbstractTable $table, int $operation = self::DO_ALL): void
     {
         if (!$this->requiresRebuild($table)) {
             //Nothing special, can be handled as usually
@@ -115,7 +120,7 @@ class SQLiteHandler extends Handler
     /**
      * {@inheritdoc}
      */
-    public function createColumn(AbstractTable $table, AbstractColumn $column): void
+    public function createColumn(SpiralAbstractTable $table, SpiralAbstractColumn $column): void
     {
         //Not supported
     }
@@ -123,7 +128,7 @@ class SQLiteHandler extends Handler
     /**
      * {@inheritdoc}
      */
-    public function dropColumn(AbstractTable $table, AbstractColumn $column): void
+    public function dropColumn(SpiralAbstractTable $table, SpiralAbstractColumn $column): void
     {
         //Not supported
     }
@@ -132,9 +137,9 @@ class SQLiteHandler extends Handler
      * {@inheritdoc}
      */
     public function alterColumn(
-        AbstractTable $table,
-        AbstractColumn $initial,
-        AbstractColumn $column
+        SpiralAbstractTable $table,
+        SpiralAbstractColumn $initial,
+        SpiralAbstractColumn $column
     ): void {
         //Not supported
     }
@@ -142,7 +147,7 @@ class SQLiteHandler extends Handler
     /**
      * {@inheritdoc}
      */
-    public function createForeignKey(AbstractTable $table, AbstractForeignKey $foreignKey): void
+    public function createForeignKey(SpiralAbstractTable $table, SpiralAbstractForeignKey $foreignKey): void
     {
         //Not supported
     }
@@ -150,7 +155,7 @@ class SQLiteHandler extends Handler
     /**
      * {@inheritdoc}
      */
-    public function dropForeignKey(AbstractTable $table, AbstractForeignKey $foreignKey): void
+    public function dropForeignKey(SpiralAbstractTable $table, SpiralAbstractForeignKey $foreignKey): void
     {
         //Not supported
     }
@@ -159,9 +164,9 @@ class SQLiteHandler extends Handler
      * {@inheritdoc}
      */
     public function alterForeignKey(
-        AbstractTable $table,
-        AbstractForeignKey $initial,
-        AbstractForeignKey $foreignKey
+        SpiralAbstractTable $table,
+        SpiralAbstractForeignKey $initial,
+        SpiralAbstractForeignKey $foreignKey
     ): void {
         //Not supported
     }
@@ -172,7 +177,7 @@ class SQLiteHandler extends Handler
      * @param AbstractTable $table
      * @return AbstractTable
      */
-    protected function createTemporary(AbstractTable $table): AbstractTable
+    protected function createTemporary(SpiralAbstractTable $table): AbstractTable
     {
         //Temporary table is required to copy data over
         $temporary = clone $table;

--- a/src/Driver/SQLite/Schema/SQLiteColumn.php
+++ b/src/Driver/SQLite/Schema/SQLiteColumn.php
@@ -11,8 +11,10 @@ declare(strict_types=1);
 
 namespace Cycle\Database\Driver\SQLite\Schema;
 
-use Cycle\Database\Driver\DriverInterface;
 use Cycle\Database\Schema\AbstractColumn;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
+
+interface_exists(SpiralDriverInterface::class);
 
 class SQLiteColumn extends AbstractColumn
 {
@@ -136,7 +138,7 @@ class SQLiteColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    public function sqlStatement(DriverInterface $driver): string
+    public function sqlStatement(SpiralDriverInterface $driver): string
     {
         $statement = parent::sqlStatement($driver);
         if ($this->getAbstractType() !== 'enum') {
@@ -247,7 +249,7 @@ class SQLiteColumn extends AbstractColumn
     /**
      * {@inheritdoc}
      */
-    protected function quoteEnum(DriverInterface $driver): string
+    protected function quoteEnum(SpiralDriverInterface $driver): string
     {
         return '';
     }

--- a/src/Driver/SQLite/Schema/SQLiteForeignKey.php
+++ b/src/Driver/SQLite/Schema/SQLiteForeignKey.php
@@ -11,8 +11,11 @@ declare(strict_types=1);
 
 namespace Cycle\Database\Driver\SQLite\Schema;
 
-use Cycle\Database\Driver\DriverInterface;
 use Cycle\Database\Schema\AbstractForeignKey;
+use Spiral\Database\Schema\AbstractForeignKey as SpiralAbstractForeignKey;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
+
+interface_exists(SpiralDriverInterface::class);
 
 class SQLiteForeignKey extends AbstractForeignKey
 {
@@ -29,7 +32,7 @@ class SQLiteForeignKey extends AbstractForeignKey
     /**
      * {@inheritdoc}
      */
-    public function sqlStatement(DriverInterface $driver): string
+    public function sqlStatement(SpiralDriverInterface $driver): string
     {
         $statement = [];
 
@@ -51,7 +54,7 @@ class SQLiteForeignKey extends AbstractForeignKey
      * @param AbstractForeignKey $initial
      * @return bool
      */
-    public function compare(AbstractForeignKey $initial): bool
+    public function compare(SpiralAbstractForeignKey $initial): bool
     {
         return $this->getColumns() === $initial->getColumns()
             && $this->getForeignTable() === $initial->getForeignTable()

--- a/src/Driver/SQLite/Schema/SQLiteIndex.php
+++ b/src/Driver/SQLite/Schema/SQLiteIndex.php
@@ -11,8 +11,10 @@ declare(strict_types=1);
 
 namespace Cycle\Database\Driver\SQLite\Schema;
 
-use Cycle\Database\Driver\DriverInterface;
 use Cycle\Database\Schema\AbstractIndex;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
+
+interface_exists(SpiralDriverInterface::class);
 
 class SQLiteIndex extends AbstractIndex
 {
@@ -55,7 +57,7 @@ class SQLiteIndex extends AbstractIndex
     /**
      * @inheritdoc
      */
-    public function sqlStatement(DriverInterface $driver, bool $includeTable = true): string
+    public function sqlStatement(SpiralDriverInterface $driver, bool $includeTable = true): string
     {
         $statement = [$this->isUnique() ? 'UNIQUE INDEX' : 'INDEX'];
 

--- a/src/Exception/HandlerException.php
+++ b/src/Exception/HandlerException.php
@@ -11,15 +11,18 @@ declare(strict_types=1);
 
 namespace Cycle\Database\Exception;
 
+use Spiral\Database\Exception\StatementException as SpiralStatementException;
+
 /**
  * Schema sync related exception.
  */
 class HandlerException extends DriverException implements StatementExceptionInterface
 {
     /**
-     * @param StatementException $e
+     * @param SpiralStatementException|StatementException $e The signature of this
+     *        argument will be changed to {@see StatementException} in future release.
      */
-    public function __construct(StatementException $e)
+    public function __construct(SpiralStatementException $e)
     {
         parent::__construct($e->getMessage(), $e->getCode(), $e);
     }

--- a/src/Exception/HandlerException.php
+++ b/src/Exception/HandlerException.php
@@ -13,14 +13,15 @@ namespace Cycle\Database\Exception;
 
 use Spiral\Database\Exception\StatementException as SpiralStatementException;
 
+class_exists(SpiralStatementException::class);
+
 /**
  * Schema sync related exception.
  */
 class HandlerException extends DriverException implements StatementExceptionInterface
 {
     /**
-     * @param SpiralStatementException|StatementException $e The signature of this
-     *        argument will be changed to {@see StatementException} in future release.
+     * @param StatementException $e
      */
     public function __construct(SpiralStatementException $e)
     {

--- a/src/Query/ActiveQuery.php
+++ b/src/Query/ActiveQuery.php
@@ -15,6 +15,11 @@ use Cycle\Database\Driver\DriverInterface;
 use Cycle\Database\Exception\BuilderException;
 use Cycle\Database\Exception\StatementException;
 use Throwable;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
+use Spiral\Database\Query\QueryParameters as SpiralQueryParameters;
+
+interface_exists(SpiralDriverInterface::class);
+class_exists(SpiralQueryParameters::class);
 
 /**
  * QueryBuilder classes generate set of control tokens for query compilers, this is query level
@@ -66,7 +71,7 @@ abstract class ActiveQuery implements QueryInterface
      * @param string|null     $prefix
      * @return QueryInterface|$this
      */
-    public function withDriver(DriverInterface $driver, string $prefix = null): QueryInterface
+    public function withDriver(SpiralDriverInterface $driver, string $prefix = null): QueryInterface
     {
         $query = clone $this;
         $query->driver = $driver;
@@ -97,7 +102,7 @@ abstract class ActiveQuery implements QueryInterface
      * @param QueryParameters|null $parameters
      * @return string
      */
-    public function sqlStatement(QueryParameters $parameters = null): string
+    public function sqlStatement(SpiralQueryParameters $parameters = null): string
     {
         if ($this->driver === null) {
             throw new BuilderException('Unable to build query without associated driver');

--- a/src/Query/BuilderInterface.php
+++ b/src/Query/BuilderInterface.php
@@ -12,6 +12,9 @@ declare(strict_types=1);
 namespace Cycle\Database\Query;
 
 use Cycle\Database\Driver\DriverInterface;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
+
+interface_exists(SpiralDriverInterface::class);
 
 /**
  * Responsible for query initiation in a context of specific driver.
@@ -22,7 +25,7 @@ interface BuilderInterface
      * @param DriverInterface $driver
      * @return BuilderInterface|$this
      */
-    public function withDriver(DriverInterface $driver): self;
+    public function withDriver(SpiralDriverInterface $driver): self;
 
     /**
      * Get InsertQuery builder with driver specific query compiler.

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -12,10 +12,17 @@ declare(strict_types=1);
 namespace Cycle\Database\Query;
 
 use Cycle\Database\Driver\DriverInterface;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
 use Spiral\Database\Query\SelectQuery as SpiralSelectQuery;
 use Spiral\Database\Query\InsertQuery as SpiralInsertQuery;
 use Spiral\Database\Query\UpdateQuery as SpiralUpdateQuery;
 use Spiral\Database\Query\DeleteQuery as SpiralDeleteQuery;
+
+interface_exists(SpiralDriverInterface::class);
+class_exists(SpiralSelectQuery::class);
+class_exists(SpiralInsertQuery::class);
+class_exists(SpiralUpdateQuery::class);
+class_exists(SpiralDeleteQuery::class);
 
 /**
  * Initiates active queries.
@@ -40,14 +47,10 @@ final class QueryBuilder implements BuilderInterface
     /**
      * QueryBuilder constructor.
      *
-     * @param SpiralSelectQuery|SelectQuery $selectQuery The signature of this
-     *        argument will be changed to {@see SelectQuery} in future release.
-     * @param SpiralInsertQuery|InsertQuery $insertQuery The signature of this
-     *        argument will be changed to {@see InsertQuery} in future release.
-     * @param SpiralUpdateQuery|UpdateQuery $updateQuery The signature of this
-     *        argument will be changed to {@see UpdateQuery} in future release.
-     * @param SpiralDeleteQuery|DeleteQuery $deleteQuery The signature of this
-     *        argument will be changed to {@see DeleteQuery} in future release.
+     * @param SelectQuery $selectQuery
+     * @param InsertQuery $insertQuery
+     * @param UpdateQuery $updateQuery
+     * @param DeleteQuery $deleteQuery
      */
     public function __construct(
         SpiralSelectQuery $selectQuery,
@@ -65,7 +68,7 @@ final class QueryBuilder implements BuilderInterface
      * @param DriverInterface $driver
      * @return BuilderInterface
      */
-    public function withDriver(DriverInterface $driver): BuilderInterface
+    public function withDriver(SpiralDriverInterface $driver): BuilderInterface
     {
         $builder = clone $this;
         $builder->driver = $driver;

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -12,6 +12,10 @@ declare(strict_types=1);
 namespace Cycle\Database\Query;
 
 use Cycle\Database\Driver\DriverInterface;
+use Spiral\Database\Query\SelectQuery as SpiralSelectQuery;
+use Spiral\Database\Query\InsertQuery as SpiralInsertQuery;
+use Spiral\Database\Query\UpdateQuery as SpiralUpdateQuery;
+use Spiral\Database\Query\DeleteQuery as SpiralDeleteQuery;
 
 /**
  * Initiates active queries.
@@ -36,16 +40,20 @@ final class QueryBuilder implements BuilderInterface
     /**
      * QueryBuilder constructor.
      *
-     * @param SelectQuery $selectQuery
-     * @param InsertQuery $insertQuery
-     * @param UpdateQuery $updateQuery
-     * @param DeleteQuery $deleteQuery
+     * @param SpiralSelectQuery|SelectQuery $selectQuery The signature of this
+     *        argument will be changed to {@see SelectQuery} in future release.
+     * @param SpiralInsertQuery|InsertQuery $insertQuery The signature of this
+     *        argument will be changed to {@see InsertQuery} in future release.
+     * @param SpiralUpdateQuery|UpdateQuery $updateQuery The signature of this
+     *        argument will be changed to {@see UpdateQuery} in future release.
+     * @param SpiralDeleteQuery|DeleteQuery $deleteQuery The signature of this
+     *        argument will be changed to {@see DeleteQuery} in future release.
      */
     public function __construct(
-        SelectQuery $selectQuery,
-        InsertQuery $insertQuery,
-        UpdateQuery $updateQuery,
-        DeleteQuery $deleteQuery
+        SpiralSelectQuery $selectQuery,
+        SpiralInsertQuery $insertQuery,
+        SpiralUpdateQuery $updateQuery,
+        SpiralDeleteQuery $deleteQuery
     ) {
         $this->selectQuery = $selectQuery;
         $this->insertQuery = $insertQuery;

--- a/src/Query/QueryInterface.php
+++ b/src/Query/QueryInterface.php
@@ -13,6 +13,9 @@ namespace Cycle\Database\Query;
 
 use Cycle\Database\Driver\DriverInterface;
 use Cycle\Database\Injection\FragmentInterface;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
+
+interface_exists(SpiralDriverInterface::class);
 
 interface QueryInterface extends FragmentInterface
 {
@@ -23,7 +26,7 @@ interface QueryInterface extends FragmentInterface
      * @param string|null     $prefix
      * @return $this
      */
-    public function withDriver(DriverInterface $driver, string $prefix = null): self;
+    public function withDriver(SpiralDriverInterface $driver, string $prefix = null): self;
 
     /**
      * @return DriverInterface|null

--- a/src/Query/QueryParameters.php
+++ b/src/Query/QueryParameters.php
@@ -12,6 +12,9 @@ declare(strict_types=1);
 namespace Cycle\Database\Query;
 
 use Cycle\Database\Injection\ParameterInterface;
+use Spiral\Database\Injection\ParameterInterface as SpiralParameterInterface;
+
+interface_exists(SpiralParameterInterface::class);
 
 /**
  * Query parameter bindings.
@@ -23,7 +26,7 @@ final class QueryParameters
     /**
      * @param ParameterInterface $parameter
      */
-    public function push(ParameterInterface $parameter): void
+    public function push(SpiralParameterInterface $parameter): void
     {
         if ($parameter->isArray()) {
             foreach ($parameter->getValue() as $value) {

--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -22,6 +22,9 @@ use Cycle\Database\Query\Traits\WhereTrait;
 use Cycle\Database\StatementInterface;
 use Spiral\Pagination\PaginableInterface;
 use Throwable;
+use Spiral\Database\Injection\FragmentInterface as SpiralFragmentInterface;
+
+interface_exists(SpiralFragmentInterface::class);
 
 /**
  * Builds select sql statements.
@@ -210,7 +213,7 @@ class SelectQuery extends ActiveQuery implements
      * @param FragmentInterface $query
      * @return self|$this
      */
-    public function union(FragmentInterface $query): SelectQuery
+    public function union(SpiralFragmentInterface $query): SelectQuery
     {
         $this->unionTokens[] = ['', $query];
 
@@ -224,7 +227,7 @@ class SelectQuery extends ActiveQuery implements
      *
      * @return self|$this
      */
-    public function unionAll(FragmentInterface $query): SelectQuery
+    public function unionAll(SpiralFragmentInterface $query): SelectQuery
     {
         $this->unionTokens[] = ['ALL', $query];
 

--- a/src/Schema/AbstractColumn.php
+++ b/src/Schema/AbstractColumn.php
@@ -20,6 +20,11 @@ use Cycle\Database\Injection\Fragment;
 use Cycle\Database\Injection\FragmentInterface;
 use Cycle\Database\Query\QueryParameters;
 use Cycle\Database\Schema\Traits\ElementTrait;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
+use Spiral\Database\Schema\AbstractColumn as SpiralAbstractColumn;
+
+interface_exists(SpiralDriverInterface::class);
+class_exists(SpiralAbstractColumn::class);
 
 /**
  * Abstract column schema with read (see ColumnInterface) and write abilities. Must be implemented
@@ -650,7 +655,7 @@ abstract class AbstractColumn implements ColumnInterface, ElementInterface
     /**
      * {@inheritdoc}
      */
-    public function sqlStatement(DriverInterface $driver): string
+    public function sqlStatement(SpiralDriverInterface $driver): string
     {
         $statement = [$driver->identifier($this->name), $this->type];
 
@@ -678,7 +683,7 @@ abstract class AbstractColumn implements ColumnInterface, ElementInterface
      * @param AbstractColumn $initial
      * @return bool
      */
-    public function compare(AbstractColumn $initial): bool
+    public function compare(SpiralAbstractColumn $initial): bool
     {
         $normalized = clone $initial;
 
@@ -724,7 +729,7 @@ abstract class AbstractColumn implements ColumnInterface, ElementInterface
      * @param DriverInterface $driver
      * @return string
      */
-    protected function quoteEnum(DriverInterface $driver): string
+    protected function quoteEnum(SpiralDriverInterface $driver): string
     {
         $enumValues = [];
         foreach ($this->enumValues as $value) {
@@ -744,7 +749,7 @@ abstract class AbstractColumn implements ColumnInterface, ElementInterface
      * @param DriverInterface $driver
      * @return string
      */
-    protected function quoteDefault(DriverInterface $driver): string
+    protected function quoteDefault(SpiralDriverInterface $driver): string
     {
         $defaultValue = $this->getDefaultValue();
         if ($defaultValue === null) {

--- a/src/Schema/AbstractForeignKey.php
+++ b/src/Schema/AbstractForeignKey.php
@@ -14,6 +14,11 @@ namespace Cycle\Database\Schema;
 use Cycle\Database\Driver\DriverInterface;
 use Cycle\Database\ForeignKeyInterface;
 use Cycle\Database\Schema\Traits\ElementTrait;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
+use Spiral\Database\Schema\AbstractForeignKey as SpiralAbstractForeignKey;
+
+interface_exists(SpiralDriverInterface::class);
+class_exists(SpiralAbstractForeignKey::class);
 
 /**
  * Abstract foreign schema with read (see ReferenceInterface) and write abilities. Must be
@@ -186,7 +191,7 @@ abstract class AbstractForeignKey implements ForeignKeyInterface, ElementInterfa
      * @param DriverInterface $driver
      * @return string
      */
-    public function sqlStatement(DriverInterface $driver): string
+    public function sqlStatement(SpiralDriverInterface $driver): string
     {
         $statement = [];
 
@@ -208,7 +213,7 @@ abstract class AbstractForeignKey implements ForeignKeyInterface, ElementInterfa
      * @param AbstractForeignKey $initial
      * @return bool
      */
-    public function compare(AbstractForeignKey $initial): bool
+    public function compare(SpiralAbstractForeignKey $initial): bool
     {
         // soft compare
         return $this == clone $initial;
@@ -219,7 +224,7 @@ abstract class AbstractForeignKey implements ForeignKeyInterface, ElementInterfa
      * @param array           $columns
      * @return string
      */
-    protected function packColumns(DriverInterface $driver, array $columns): string
+    protected function packColumns(SpiralDriverInterface $driver, array $columns): string
     {
         return implode(', ', array_map([$driver, 'identifier'], $columns));
     }

--- a/src/Schema/AbstractIndex.php
+++ b/src/Schema/AbstractIndex.php
@@ -14,6 +14,11 @@ namespace Cycle\Database\Schema;
 use Cycle\Database\Driver\DriverInterface;
 use Cycle\Database\IndexInterface;
 use Cycle\Database\Schema\Traits\ElementTrait;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
+use Spiral\Database\Schema\AbstractIndex as SpiralAbstractIndex;
+
+interface_exists(SpiralDriverInterface::class);
+class_exists(SpiralAbstractIndex::class);
 
 /**
  * Abstract index schema with read (see IndexInterface) and write abilities. Must be implemented
@@ -157,7 +162,7 @@ abstract class AbstractIndex implements IndexInterface, ElementInterface
      * @param bool            $includeTable Include table ON statement (not required for inline index creation).
      * @return string
      */
-    public function sqlStatement(DriverInterface $driver, bool $includeTable = true): string
+    public function sqlStatement(SpiralDriverInterface $driver, bool $includeTable = true): string
     {
         $statement = [$this->isUnique() ? 'UNIQUE INDEX' : 'INDEX'];
 
@@ -188,7 +193,7 @@ abstract class AbstractIndex implements IndexInterface, ElementInterface
      * @param AbstractIndex $initial
      * @return bool
      */
-    public function compare(AbstractIndex $initial): bool
+    public function compare(SpiralAbstractIndex $initial): bool
     {
         return $this == clone $initial;
     }

--- a/src/Schema/AbstractTable.php
+++ b/src/Schema/AbstractTable.php
@@ -18,6 +18,10 @@ use Cycle\Database\Exception\HandlerException;
 use Cycle\Database\Exception\SchemaException;
 use Cycle\Database\TableInterface;
 use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
+use Spiral\Database\Schema\State as SpiralState;
+
+interface_exists(SpiralDriverInterface::class);
+class_exists(SpiralState::class);
 
 /**
  * AbstractTable class used to describe and manage state of specified table. It provides ability to
@@ -99,8 +103,7 @@ abstract class AbstractTable implements TableInterface, ElementInterface
     private $prefix;
 
     /**
-     * @param SpiralDriverInterface|DriverInterface $driver Parent driver. The signature
-     *        of this argument will be changed to {@see DriverInterface} in future release.
+     * @param DriverInterface $driver Parent driver.
      * @param string $name Table name, must include table prefix.
      * @param string $prefix Database specific table prefix.
      */
@@ -645,7 +648,7 @@ abstract class AbstractTable implements TableInterface, ElementInterface
      *
      * @return self|$this
      */
-    public function setState(State $state = null): AbstractTable
+    public function setState(SpiralState $state = null): AbstractTable
     {
         $this->current = new State($this->initial->getName());
 
@@ -842,7 +845,7 @@ abstract class AbstractTable implements TableInterface, ElementInterface
      *
      * @param State $state
      */
-    protected function initSchema(State $state): void
+    protected function initSchema(SpiralState $state): void
     {
         foreach ($this->fetchColumns() as $column) {
             $state->registerColumn($column);

--- a/src/Schema/AbstractTable.php
+++ b/src/Schema/AbstractTable.php
@@ -17,6 +17,7 @@ use Cycle\Database\Exception\DriverException;
 use Cycle\Database\Exception\HandlerException;
 use Cycle\Database\Exception\SchemaException;
 use Cycle\Database\TableInterface;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
 
 /**
  * AbstractTable class used to describe and manage state of specified table. It provides ability to
@@ -98,11 +99,12 @@ abstract class AbstractTable implements TableInterface, ElementInterface
     private $prefix;
 
     /**
-     * @param DriverInterface $driver Parent driver.
-     * @param string          $name   Table name, must include table prefix.
-     * @param string          $prefix Database specific table prefix.
+     * @param SpiralDriverInterface|DriverInterface $driver Parent driver. The signature
+     *        of this argument will be changed to {@see DriverInterface} in future release.
+     * @param string $name Table name, must include table prefix.
+     * @param string $prefix Database specific table prefix.
      */
-    public function __construct(DriverInterface $driver, string $name, string $prefix)
+    public function __construct(SpiralDriverInterface $driver, string $name, string $prefix)
     {
         $this->driver = $driver;
         $this->prefix = $prefix;

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -13,6 +13,8 @@ namespace Cycle\Database\Schema;
 
 use Spiral\Database\Schema\State as SpiralState;
 
+class_exists(SpiralState::class);
+
 /**
  * Compares two table states.
  */
@@ -25,10 +27,8 @@ final class Comparator implements ComparatorInterface
     private $current;
 
     /**
-     * @param SpiralState|State $initial The signature of this argument
-     *        will be changed to {@see State} in future release.
-     * @param SpiralState|State $current The signature of this argument
-     *        will be changed to {@see State} in future release.
+     * @param State $initial
+     * @param State $current
      */
     public function __construct(SpiralState $initial, SpiralState $current)
     {

--- a/src/Schema/Comparator.php
+++ b/src/Schema/Comparator.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Cycle\Database\Schema;
 
+use Spiral\Database\Schema\State as SpiralState;
+
 /**
  * Compares two table states.
  */
@@ -23,10 +25,12 @@ final class Comparator implements ComparatorInterface
     private $current;
 
     /**
-     * @param State $initial
-     * @param State $current
+     * @param SpiralState|State $initial The signature of this argument
+     *        will be changed to {@see State} in future release.
+     * @param SpiralState|State $current The signature of this argument
+     *        will be changed to {@see State} in future release.
      */
-    public function __construct(State $initial, State $current)
+    public function __construct(SpiralState $initial, SpiralState $current)
     {
         $this->initial = $initial;
         $this->current = $current;

--- a/src/Schema/Reflector.php
+++ b/src/Schema/Reflector.php
@@ -15,6 +15,7 @@ use Cycle\Database\Driver\Driver;
 use Cycle\Database\Driver\DriverInterface;
 use Cycle\Database\Driver\HandlerInterface;
 use Throwable;
+use Spiral\Database\Schema\AbstractTable as SpiralAbstractTable;
 
 /**
  * Saves multiple linked tables at once but treating their cross dependency.
@@ -45,7 +46,7 @@ final class Reflector
      *
      * @param AbstractTable $table
      */
-    public function addTable(AbstractTable $table): void
+    public function addTable(SpiralAbstractTable $table): void
     {
         $this->tables[$table->getName()] = $table;
         $this->dependencies[$table->getName()] = $table->getDependencies();

--- a/src/Schema/State.php
+++ b/src/Schema/State.php
@@ -11,6 +11,14 @@ declare(strict_types=1);
 
 namespace Cycle\Database\Schema;
 
+use Spiral\Database\Schema\AbstractColumn as SpiralAbstractColumn;
+use Spiral\Database\Schema\AbstractIndex as SpiralAbstractIndex;
+use Spiral\Database\Schema\AbstractForeignKey as SpiralAbstractForeignKey;
+
+class_exists(SpiralAbstractColumn::class);
+class_exists(SpiralAbstractIndex::class);
+class_exists(SpiralAbstractForeignKey::class);
+
 /**
  * TableSchema helper used to store original table elements and run comparation between them.
  *
@@ -165,7 +173,7 @@ final class State
     /**
      * @param AbstractColumn $column
      */
-    public function registerColumn(AbstractColumn $column): void
+    public function registerColumn(SpiralAbstractColumn $column): void
     {
         $this->columns[$column->getName()] = $column;
     }
@@ -173,7 +181,7 @@ final class State
     /**
      * @param AbstractIndex $index
      */
-    public function registerIndex(AbstractIndex $index): void
+    public function registerIndex(SpiralAbstractIndex $index): void
     {
         $this->indexes[$index->getName()] = $index;
     }
@@ -181,7 +189,7 @@ final class State
     /**
      * @param AbstractForeignKey $reference
      */
-    public function registerForeignKey(AbstractForeignKey $reference): void
+    public function registerForeignKey(SpiralAbstractForeignKey $reference): void
     {
         $this->foreignKeys[$reference->getName()] = $reference;
     }
@@ -192,7 +200,7 @@ final class State
      * @param AbstractColumn $column
      * @return self
      */
-    public function forgetColumn(AbstractColumn $column): State
+    public function forgetColumn(SpiralAbstractColumn $column): State
     {
         foreach ($this->columns as $name => $columnSchema) {
             // todo: need better compare
@@ -210,7 +218,7 @@ final class State
      *
      * @param AbstractIndex $index
      */
-    public function forgetIndex(AbstractIndex $index): void
+    public function forgetIndex(SpiralAbstractIndex $index): void
     {
         foreach ($this->indexes as $name => $indexSchema) {
             // todo: need better compare
@@ -226,7 +234,7 @@ final class State
      *
      * @param AbstractForeignKey $foreignKey
      */
-    public function forgerForeignKey(AbstractForeignKey $foreignKey): void
+    public function forgerForeignKey(SpiralAbstractForeignKey $foreignKey): void
     {
         foreach ($this->foreignKeys as $name => $foreignSchema) {
             // todo: need better compare

--- a/src/Schema/Traits/ElementTrait.php
+++ b/src/Schema/Traits/ElementTrait.php
@@ -11,7 +11,10 @@ declare(strict_types=1);
 
 namespace Cycle\Database\Schema\Traits;
 
-use Cycle\Database\Driver\Driver;
+use Cycle\Database\Driver\DriverInterface;
+use Spiral\Database\Driver\DriverInterface as SpiralDriverInterface;
+
+interface_exists(SpiralDriverInterface::class);
 
 trait ElementTrait
 {
@@ -57,8 +60,8 @@ trait ElementTrait
     /**
      * Element creation/definition syntax (specific to parent driver).
      *
-     * @param Driver $driver
+     * @param DriverInterface $driver
      * @return string
      */
-    abstract public function sqlStatement(Driver $driver): string;
+    abstract public function sqlStatement(SpiralDriverInterface $driver): string;
 }

--- a/src/Table.php
+++ b/src/Table.php
@@ -17,6 +17,7 @@ use Cycle\Database\Query\InsertQuery;
 use Cycle\Database\Query\SelectQuery;
 use Cycle\Database\Query\UpdateQuery;
 use Cycle\Database\Schema\AbstractTable;
+use Spiral\Database\DatabaseInterface as SpiralDatabaseInterface;
 
 /**
  * Represent table level abstraction with simplified access to SelectQuery associated with such
@@ -36,8 +37,9 @@ final class Table implements TableInterface, \IteratorAggregate, \Countable
     private $name;
 
     /**
-     * @param DatabaseInterface $database Parent DBAL database.
-     * @param string            $name     Table name without prefix.
+     * @param SpiralDatabaseInterface|DatabaseInterface $database Parent DBAL database. The signature
+     *        of this argument will be changed to {@see DatabaseInterface} in future release.
+     * @param string $name Table name without prefix.
      */
     public function __construct(DatabaseInterface $database, string $name)
     {

--- a/src/Table.php
+++ b/src/Table.php
@@ -19,6 +19,8 @@ use Cycle\Database\Query\UpdateQuery;
 use Cycle\Database\Schema\AbstractTable;
 use Spiral\Database\DatabaseInterface as SpiralDatabaseInterface;
 
+interface_exists(SpiralDatabaseInterface::class);
+
 /**
  * Represent table level abstraction with simplified access to SelectQuery associated with such
  * table.
@@ -37,11 +39,10 @@ final class Table implements TableInterface, \IteratorAggregate, \Countable
     private $name;
 
     /**
-     * @param SpiralDatabaseInterface|DatabaseInterface $database Parent DBAL database. The signature
-     *        of this argument will be changed to {@see DatabaseInterface} in future release.
+     * @param DatabaseInterface $database Parent DBAL database.
      * @param string $name Table name without prefix.
      */
-    public function __construct(DatabaseInterface $database, string $name)
+    public function __construct(SpiralDatabaseInterface $database, string $name)
     {
         $this->name = $name;
         $this->database = $database;

--- a/src/polyfill.php
+++ b/src/polyfill.php
@@ -30,19 +30,3 @@ spl_autoload_register(static function (string $class) {
         class_alias($original, $class);
     }
 });
-
-// Preload some aliases
-interface_exists(\Spiral\Database\Driver\CachingCompilerInterface::class);
-interface_exists(\Spiral\Database\Driver\CompilerInterface::class);
-interface_exists(\Spiral\Database\Driver\HandlerInterface::class);
-interface_exists(\Spiral\Database\Driver\DriverInterface::class);
-interface_exists(\Spiral\Database\Query\BuilderInterface::class);
-interface_exists(\Spiral\Database\DatabaseInterface::class);
-
-class_exists(\Spiral\Database\Exception\StatementException::class);
-class_exists(\Spiral\Database\Config\DatabaseConfig::class);
-class_exists(\Spiral\Database\Query\SelectQuery::class);
-class_exists(\Spiral\Database\Query\InsertQuery::class);
-class_exists(\Spiral\Database\Query\UpdateQuery::class);
-class_exists(\Spiral\Database\Query\DeleteQuery::class);
-class_exists(\Spiral\Database\Schema\State::class);

--- a/src/polyfill.php
+++ b/src/polyfill.php
@@ -16,6 +16,7 @@ class_alias(
     \Spiral\Database\Driver\SQLServer\Schema\SQlServerForeignKey::class
 );
 
+
 spl_autoload_register(static function (string $class) {
     if (strpos($class, 'Spiral\\Database\\') === 0) {
         $original = 'Cycle\\Database\\' . substr($class, 16);
@@ -29,3 +30,19 @@ spl_autoload_register(static function (string $class) {
         class_alias($original, $class);
     }
 });
+
+// Preload some aliases
+interface_exists(\Spiral\Database\Driver\CachingCompilerInterface::class);
+interface_exists(\Spiral\Database\Driver\CompilerInterface::class);
+interface_exists(\Spiral\Database\Driver\HandlerInterface::class);
+interface_exists(\Spiral\Database\Driver\DriverInterface::class);
+interface_exists(\Spiral\Database\Query\BuilderInterface::class);
+interface_exists(\Spiral\Database\DatabaseInterface::class);
+
+class_exists(\Spiral\Database\Exception\StatementException::class);
+class_exists(\Spiral\Database\Config\DatabaseConfig::class);
+class_exists(\Spiral\Database\Query\SelectQuery::class);
+class_exists(\Spiral\Database\Query\InsertQuery::class);
+class_exists(\Spiral\Database\Query\UpdateQuery::class);
+class_exists(\Spiral\Database\Query\DeleteQuery::class);
+class_exists(\Spiral\Database\Schema\State::class);

--- a/src/polyfill.php
+++ b/src/polyfill.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 // Replaces: SQlServerForeignKey to SQLServerForeignKey
 class_alias(
     \Cycle\Database\Driver\SQLServer\Schema\SQLServerForeignKey::class,
-    \Spiral\Database\Driver\SQLServer\Schema\SQlServerForeignKey::class,
+    \Spiral\Database\Driver\SQLServer\Schema\SQlServerForeignKey::class
 );
 
 spl_autoload_register(static function (string $class) {


### PR DESCRIPTION
Using Spiral/Database alias instead of Cycle/Database for DI backward compatible. 