### PR TITLE
Add psr/log dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "require": {
         "php": ">=8.0",
         "ext-pdo": "*",
+        "psr/log": "^1.0",
         "spiral/core": "^2.9",
         "spiral/pagination": "^2.9"
     },
@@ -50,3 +51,4 @@
     "minimum-stability": "dev",
     "prefer-stable": true
 }
+


### PR DESCRIPTION
Steps to reproduce

1. `composer install --no-dev`
2. Running the below example code will complain

example.php
```php
<?php

require_once "vendor/autoload.php";

use Cycle\Database\DatabaseManager;
use Cycle\Database\Driver;      // unused import here
use Cycle\Database\Config;

$dbal = new DatabaseManager(new Config\DatabaseConfig([
    'databases' => [
        'default' => [
            'driver' => 'runtime'
        ],
    ],
    'connections' => [
        'runtime' => new Config\SQLiteDriverConfig(
            connection: new Config\SQLite\FileConnectionConfig(
                database: __DIR__ . './runtime/database.sqlite'
            ),
            queryCache: true,
        ),
    ],
]));

```

Error message

```
PHP Warning:  Uncaught Error: Interface "Psr\Log\LoggerAwareInterface" not found in ../cycle/database/src/Driver/Driver.php:36
```

Another way to reproduce is to require cycle/orm and do not require cycle/annotated and try to setup as per above example file.