### PR TITLE
Fixed public method typo

### DIFF
--- a/src/Schema/AbstractTable.php
+++ b/src/Schema/AbstractTable.php
@@ -539,7 +539,7 @@ abstract class AbstractTable implements TableInterface, ElementInterface
         }
 
         //Dropping foreign from current schema
-        $this->current->forgerForeignKey($schema);
+        $this->current->forgetForeignKey($schema);
 
         return $this;
     }
@@ -675,7 +675,7 @@ abstract class AbstractTable implements TableInterface, ElementInterface
         // declare all FKs dropped on tables scheduled for removal
         if ($this->status === self::STATUS_DECLARED_DROPPED) {
             foreach ($target->getForeignKeys() as $fk) {
-                $target->current->forgerForeignKey($fk);
+                $target->current->forgetForeignKey($fk);
             }
         }
 
@@ -692,7 +692,7 @@ abstract class AbstractTable implements TableInterface, ElementInterface
 
             foreach ($target->getForeignKeys() as $foreign) {
                 if ($column->getName() === $foreign->getColumns()) {
-                    $target->current->forgerForeignKey($foreign);
+                    $target->current->forgetForeignKey($foreign);
                 }
             }
         }
@@ -742,7 +742,7 @@ abstract class AbstractTable implements TableInterface, ElementInterface
         if (!$withForeignKeys) {
             foreach ($this->getComparator()->addedForeignKeys() as $foreign) {
                 //Excluding from creation
-                $target->current->forgerForeignKey($foreign);
+                $target->current->forgetForeignKey($foreign);
             }
         }
 

--- a/src/Schema/State.php
+++ b/src/Schema/State.php
@@ -190,7 +190,7 @@ final class State
 
     /**
      * Drop foreign key from table schema using it's forming column.
-     * @deprecated Since Cycle ORM 2.2, use Cycle\Database\Schema::forgetForeignKey($foreignKey) instead.
+     * @deprecated Since cycle/database 2.2, use {@see forgetForeignKey()} instead.
      */
     public function forgerForeignKey(AbstractForeignKey $foreignKey): void
     {

--- a/src/Schema/State.php
+++ b/src/Schema/State.php
@@ -190,8 +190,17 @@ final class State
 
     /**
      * Drop foreign key from table schema using it's forming column.
+     * @deprecated Since Cycle ORM 2.2, use Cycle\Database\Schema::forgetForeignKey($foreignKey) instead.
      */
     public function forgerForeignKey(AbstractForeignKey $foreignKey): void
+    {
+        $this->forgetForeignKey($foreignKey);
+    }
+
+    /**
+     * Drop foreign key from table schema using it's forming column.
+     */
+    public function forgetForeignKey(AbstractForeignKey $foreignKey): void
     {
         foreach ($this->foreignKeys as $name => $foreignSchema) {
             // todo: need better compare

--- a/src/Schema/State.php
+++ b/src/Schema/State.php
@@ -190,7 +190,7 @@ final class State
 
     /**
      * Drop foreign key from table schema using it's forming column.
-     * @deprecated Since cycle/database 2.2, use {@see forgetForeignKey()} instead.
+     * @deprecated Since cycle/database 2.2.0, use {@see forgetForeignKey()} instead.
      */
     public function forgerForeignKey(AbstractForeignKey $foreignKey): void
     {
@@ -199,6 +199,7 @@ final class State
 
     /**
      * Drop foreign key from table schema using it's forming column.
+     * @since 2.2.0
      */
     public function forgetForeignKey(AbstractForeignKey $foreignKey): void
     {


### PR DESCRIPTION
Typo in `Cycle\Database\Schema\State::forgerForeignKey(AbstractForeignKey)` confuses a bit while trying `forget`.
Made a quick fix. 

Thanks.