### PR TITLE
Add supporting for array values in the `IN` operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # CHANGELOG
 
-v2.2.2 (in progress)
+v2.3.0 (in progress)
 -------------------
+- Add supporting for array values in the `IN` operator by @roxblnfk
 
 v2.2.1 (02.07.2022)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 v2.3.0 (in progress)
 -------------------
-- Add supporting for array values in the `IN` operator by @roxblnfk
+- Add supporting for array values in the `IN` operator by @roxblnfk (#69)
 
 v2.2.1 (02.07.2022)
 -------------------

--- a/src/Query/Traits/TokenTrait.php
+++ b/src/Query/Traits/TokenTrait.php
@@ -15,6 +15,7 @@ use Closure;
 use Cycle\Database\Driver\CompilerInterface;
 use Cycle\Database\Exception\BuilderException;
 use Cycle\Database\Injection\FragmentInterface;
+use Cycle\Database\Injection\Parameter;
 
 trait TokenTrait
 {
@@ -104,6 +105,8 @@ trait TokenTrait
                     $operator = \strtoupper($operator);
                     if ($operator === 'BETWEEN' || $operator === 'NOT BETWEEN') {
                         throw new BuilderException('Between statements expects exactly 2 values');
+                    } elseif ($operator === 'IN' && \is_array($value)) {
+                        $value = new Parameter($value);
                     }
                 } elseif (\is_scalar($operator)) {
                     $operator = (string)$operator;

--- a/src/Query/Traits/TokenTrait.php
+++ b/src/Query/Traits/TokenTrait.php
@@ -105,7 +105,8 @@ trait TokenTrait
                     $operator = \strtoupper($operator);
                     if ($operator === 'BETWEEN' || $operator === 'NOT BETWEEN') {
                         throw new BuilderException('Between statements expects exactly 2 values');
-                    } elseif ($operator === 'IN' && \is_array($value)) {
+                    }
+                    if ($operator === 'IN' && \is_array($value)) {
                         $value = new Parameter($value);
                     }
                 } elseif (\is_scalar($operator)) {

--- a/src/Query/Traits/WhereTrait.php
+++ b/src/Query/Traits/WhereTrait.php
@@ -109,7 +109,7 @@ trait WhereTrait
     private function whereWrapper(): Closure
     {
         return static function ($parameter) {
-            \is_array($parameter) and throw new BuilderException('Arrays must be wrapped with Parameter instance');
+            \is_array($parameter) and throw new BuilderException('Arrays must be wrapped with Parameter instance.');
 
             return !$parameter instanceof ParameterInterface && !$parameter instanceof FragmentInterface
                 ? new Parameter($parameter)


### PR DESCRIPTION
Now you don't need to wrap an array value in the Parameter injection.

```php
$database->select()
    ->from(['users'])
    ->where('status', 'IN', ['active', 'blocked']);
```
