### PR TITLE
Add supporting for array values in the `NOT IN` operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 v2.3.0 (in progress)
 -------------------
-- Add supporting for array values in the `IN` operator by @roxblnfk (#69)
+- Add supporting for array values in the `IN` and `NOT IN` operators by @roxblnfk (#69, #70)
 
 v2.2.1 (02.07.2022)
 -------------------

--- a/src/Query/Traits/TokenTrait.php
+++ b/src/Query/Traits/TokenTrait.php
@@ -106,7 +106,7 @@ trait TokenTrait
                     if ($operator === 'BETWEEN' || $operator === 'NOT BETWEEN') {
                         throw new BuilderException('Between statements expects exactly 2 values');
                     }
-                    if (\is_array($value) && \in_array($operator, ['IN', 'NOT IN'])) {
+                    if (\is_array($value) && \in_array($operator, ['IN', 'NOT IN'], true)) {
                         $value = new Parameter($value);
                     }
                 } elseif (\is_scalar($operator)) {

--- a/src/Query/Traits/TokenTrait.php
+++ b/src/Query/Traits/TokenTrait.php
@@ -106,7 +106,7 @@ trait TokenTrait
                     if ($operator === 'BETWEEN' || $operator === 'NOT BETWEEN') {
                         throw new BuilderException('Between statements expects exactly 2 values');
                     }
-                    if ($operator === 'IN' && \is_array($value)) {
+                    if (\is_array($value) && \in_array($operator, ['IN', 'NOT IN'])) {
                         $value = new Parameter($value);
                     }
                 } elseif (\is_scalar($operator)) {

--- a/tests/Database/Functional/Driver/Common/Query/SelectQueryTest.php
+++ b/tests/Database/Functional/Driver/Common/Query/SelectQueryTest.php
@@ -1871,10 +1871,11 @@ WHERE {name} = \'Antony\' AND {id} IN (SELECT{id}FROM {other}WHERE {x} = 123)',
     {
         $select = $this->database->select()
                        ->from(['users'])
-                       ->where('status', 'IN', ['active', 'blocked']);
+                       ->where('status', 'IN', ['active', 'blocked'])
+                       ->andWhere('age', 'not in', [1, 2, 3]);
 
         $this->assertSameQuery(
-            'SELECT * FROM {users} WHERE {status} IN (?, ?)',
+            'SELECT * FROM {users} WHERE {status} IN (?, ?) AND {age} NOT IN (?, ?, ?)',
             $select
         );
     }


### PR DESCRIPTION
Now you don't need to wrap an array value in the Parameter injection.

```php
$database->select()
    ->from(['users'])
    ->where('status', 'NOT IN', ['active', 'blocked']);
```
