### PR TITLE
Add supporting for array values in the `IN` and `NOT IN` operators using nested syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 v2.3.0 (in progress)
 -------------------
-- Add supporting for array values in the `IN` and `NOT IN` operators by @roxblnfk (#69, #70)
+- Add supporting for array values in the `IN` and `NOT IN` operators by @roxblnfk (#69, #70, #71)
 
 v2.2.1 (02.07.2022)
 -------------------

--- a/src/Query/Traits/TokenTrait.php
+++ b/src/Query/Traits/TokenTrait.php
@@ -241,6 +241,9 @@ trait TokenTrait
             $operation = strtoupper($operation);
             if ($operation !== 'BETWEEN' && $operation !== 'NOT BETWEEN') {
                 // AND|OR [name] [OPERATION] [nestedValue]
+                if (\is_array($value) && \in_array($operation, ['IN', 'NOT IN'], true)) {
+                    $value = new Parameter($value);
+                }
                 $tokens[] = [
                     $innerJoiner,
                     [$key, $operation, $wrapper($value)],

--- a/tests/Database/Functional/Driver/Common/Query/SelectQueryTest.php
+++ b/tests/Database/Functional/Driver/Common/Query/SelectQueryTest.php
@@ -1961,6 +1961,26 @@ WHERE {name} = \'Antony\' AND {id} IN (SELECT{id}FROM {other}WHERE {x} = 123)',
         );
     }
 
+    public function testInAndNotInWithArrayInShortWhere(): void
+    {
+        $status = ['active', 'blocked'];
+        $name = ['bar', 'foo', 'baz'];
+
+        $select = $this->database->select()
+            ->from(['users'])
+            ->where(
+                [
+                    'status' => ['IN' => $status],
+                    'name' => ['NOT IN' => $name],
+                ],
+            );
+
+        $this->assertSameQuery(
+            'SELECT * FROM {users} WHERE ({status} IN (?, ?) AND {name} NOT IN (?, ?, ?))',
+            $select,
+        );
+    }
+
     public function testDirectIsNull(): void
     {
         $select = $this->database->select()->from(['users'])

--- a/tests/Database/Functional/Driver/Common/Query/SelectQueryTest.php
+++ b/tests/Database/Functional/Driver/Common/Query/SelectQueryTest.php
@@ -1910,7 +1910,7 @@ WHERE {name} = \'Antony\' AND {id} IN (SELECT{id}FROM {other}WHERE {x} = 123)',
                        ->from(['users'])
                        ->where(
                            [
-                               'status' => ['IN' => ['active', 'blocked']],
+                               'status' => ['LIKE' => ['active', 'blocked']],
                            ]
                        );
     }


### PR DESCRIPTION
Now you don't need to wrap an array value in the Parameter injection.

```php
$database->select()
    ->from(['users'])
    ->where([
        'status' => [
            'IN' => ['active', 'blocked']
        ],
        'name' => [
            'NOT IN' => ['foo', 'bar']
        ],
    ]);
```
