### PR TITLE
Allow any type fields

### DIFF
--- a/src/Schema/AbstractColumn.php
+++ b/src/Schema/AbstractColumn.php
@@ -450,7 +450,11 @@ abstract class AbstractColumn implements ColumnInterface, ElementInterface
             $abstract = $this->aliases[$abstract];
         }
 
-        isset($this->mapping[$abstract]) or throw new SchemaException("Undefined abstract/virtual type '{$abstract}'");
+        if (!isset($this->mapping[$abstract])) {
+            $this->type = $abstract;
+
+            return $this;
+        }
 
         // Originally specified type.
         $this->userType = $abstract;


### PR DESCRIPTION
Allow to create fields of any type. This will be useful for creating a migration builder for using fields like enum, point, ip, polygon, etc.
