### PR TITLE
Remove creation of index for foreign keys.

### DIFF
--- a/src/Schema/AbstractTable.php
+++ b/src/Schema/AbstractTable.php
@@ -444,9 +444,6 @@ abstract class AbstractTable implements TableInterface, ElementInterface
         //Adding to current schema
         $this->current->registerForeignKey($foreign);
 
-        //Let's ensure index existence to performance and compatibility reasons
-        $this->index($columns);
-
         return $foreign;
     }
 


### PR DESCRIPTION
I think it should be configurable via `indexCreate` only. Right now in cycle/database (1.0.3, and I think in latest versions) if indexCreate = false, index is beeing created anyway.

I think it should be removed to skip creation of unneeded indexes.