### PR TITLE
Adding methods beforeSync and afterSync

### DIFF
--- a/src/Driver/Handler.php
+++ b/src/Driver/Handler.php
@@ -154,6 +154,22 @@ abstract class Handler implements HandlerInterface
     }
 
     /**
+     * This method will be called by Reflector in the run method before the changes are synchronized.
+     * @param AbstractTable[] $tables
+     */
+    public function beforeSync(array $tables): void
+    {
+    }
+
+    /**
+     * This method will be called by Reflector in the run method after the changes are synchronized.
+     * @param AbstractTable[] $tables
+     */
+    public function afterSync(array $tables): void
+    {
+    }
+
+    /**
      * @psalm-return non-empty-string
      */
     protected function createStatement(AbstractTable $table): string

--- a/src/Driver/Handler.php
+++ b/src/Driver/Handler.php
@@ -155,6 +155,7 @@ abstract class Handler implements HandlerInterface
 
     /**
      * This method will be called by Reflector in the run method before the changes are synchronized.
+     *
      * @param AbstractTable[] $tables
      */
     public function beforeSync(array $tables): void
@@ -163,6 +164,7 @@ abstract class Handler implements HandlerInterface
 
     /**
      * This method will be called by Reflector in the run method after the changes are synchronized.
+     *
      * @param AbstractTable[] $tables
      */
     public function afterSync(array $tables): void

--- a/src/Driver/MySQL/MySQLHandler.php
+++ b/src/Driver/MySQL/MySQLHandler.php
@@ -110,8 +110,7 @@ class MySQLHandler extends Handler
                 [$foreignKey->getName(), $this->driver->getSource(), $table->getName()]
             )->fetchAll();
 
-            return $count[0]['count'] === 1;
-
+            return (int) $count[0]['count'] === 1;
         } catch (StatementException $e) {
             throw new HandlerException($e);
         }

--- a/tests/Database/Functional/Driver/MySQL/Schema/ReflectorTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Schema/ReflectorTest.php
@@ -14,4 +14,35 @@ use Cycle\Database\Tests\Functional\Driver\Common\Schema\ReflectorTest as Common
 class ReflectorTest extends CommonClass
 {
     public const DRIVER = 'mysql';
+
+    public function testCreateTableAndLinkAndChangeLink(): void
+    {
+        $schemaA = $this->schema('a');
+        $this->assertFalse($schemaA->exists());
+
+        $schemaB = $this->schema('b');
+        $this->assertFalse($schemaB->exists());
+
+        $schemaA->primary('id');
+        $schemaA->integer('value');
+
+        $schemaB->integer('id')->primary();
+        $schemaB->string('value');
+
+        $schemaA->integer('b_id');
+        $schemaA->foreignKey(['b_id'])->references('b', ['id']);
+
+        $this->saveTables([$schemaA, $schemaB]);
+
+        $this->assertSameAsInDB($schemaA);
+        $this->assertSameAsInDB($schemaB);
+
+        $schemaA->integer('b_id')->unsigned(true);
+        $schemaB->integer('id')->unsigned(true);
+
+        $this->saveTables([$schemaA, $schemaB]);
+
+        $this->assertSameAsInDB($schemaA);
+        $this->assertSameAsInDB($schemaB);
+    }
 }

--- a/tests/Database/Unit/Schema/ReflectorTest.php
+++ b/tests/Database/Unit/Schema/ReflectorTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Unit\Schema;
+
+use Cycle\Database\Driver\DriverInterface;
+use Cycle\Database\Driver\Handler;
+use Cycle\Database\Driver\HandlerInterface;
+use Cycle\Database\Schema\AbstractTable;
+use Cycle\Database\Schema\ComparatorInterface;
+use Cycle\Database\Schema\Reflector;
+use PHPUnit\Framework\TestCase;
+
+final class ReflectorTest extends TestCase
+{
+    private Reflector $reflector;
+    private AbstractTable $table;
+
+    protected function setUp(): void
+    {
+        $this->table = $this->createMock(AbstractTable::class);
+
+        $comparator = $this->createMock(ComparatorInterface::class);
+        $comparator
+            ->expects($this->once())
+            ->method('hasChanges')
+            ->willReturn(true);
+
+        $this->table
+            ->expects($this->exactly(2))
+            ->method('getFullName')
+            ->willReturn('foo');
+        $this->table
+            ->expects($this->once())
+            ->method('getComparator')
+            ->willReturn($comparator);
+
+        $this->reflector = new Reflector();
+    }
+
+    public function testMethodBeforeSyncShouldBeCalled(): void
+    {
+        $handler = $this->createMock(Handler::class);
+        $driver = $this->createMock(DriverInterface::class);
+
+        $this->table
+            ->expects($this->exactly(4))
+            ->method('getDriver')
+            ->willReturn($driver);
+
+        $handler
+            ->expects($this->once())
+            ->method('beforeSync')
+            ->with(['foo' => $this->table]);
+        $handler
+            ->expects($this->once())
+            ->method('afterSync')
+            ->with(['foo' => $this->table]);
+
+        $driver
+            ->expects($this->exactly(2))
+            ->method('getSchemaHandler')
+            ->willReturn($handler);
+
+        $this->reflector->addTable($this->table);
+        $this->reflector->run();
+    }
+
+    public function testMethodBeforeSyncShouldNotBeCalledIfNotExists(): void
+    {
+        $handler = $this->createMock(HandlerInterface::class);
+        $driver = $this->createMock(DriverInterface::class);
+
+        $this->table
+            ->expects($this->exactly(4))
+            ->method('getDriver')
+            ->willReturn($driver);
+
+        $driver
+            ->expects($this->exactly(2))
+            ->method('getSchemaHandler')
+            ->willReturn($handler);
+
+        $this->reflector->addTable($this->table);
+        $this->reflector->run();
+    }
+}

--- a/tests/Database/Unit/Schema/ReflectorTest.php
+++ b/tests/Database/Unit/Schema/ReflectorTest.php
@@ -39,7 +39,7 @@ final class ReflectorTest extends TestCase
         $this->reflector = new Reflector();
     }
 
-    public function testMethodBeforeSyncShouldBeCalled(): void
+    public function testMethodsBeforeAndAfterSyncShouldBeCalled(): void
     {
         $handler = $this->createMock(Handler::class);
         $driver = $this->createMock(DriverInterface::class);
@@ -67,7 +67,7 @@ final class ReflectorTest extends TestCase
         $this->reflector->run();
     }
 
-    public function testMethodBeforeSyncShouldNotBeCalledIfNotExists(): void
+    public function testMethodsBeforeAndAfterSyncShouldNotBeCalledIfNotExists(): void
     {
         $handler = $this->createMock(HandlerInterface::class);
         $driver = $this->createMock(DriverInterface::class);


### PR DESCRIPTION
And fixed a bug with changing a field that has a foreign key in MySQL:

```bash
PDOException: SQLSTATE[HY000]: General error: 3780 Referencing column 'b_id' and referenced column 'id' in foreign key constraint 'a_foreign_b_id_6409dc0c5edbb' are incompatible.
```