### PR TITLE
Adding the ability to pass the port as a string

### DIFF
--- a/src/Config/MySQL/TcpConnectionConfig.php
+++ b/src/Config/MySQL/TcpConnectionConfig.php
@@ -15,6 +15,9 @@ use Cycle\Database\Config\ProvidesSourceString;
 
 class TcpConnectionConfig extends ConnectionConfig implements ProvidesSourceString
 {
+    /**
+     * @var positive-int
+     */
     public int $port;
 
     /**

--- a/src/Config/MySQL/TcpConnectionConfig.php
+++ b/src/Config/MySQL/TcpConnectionConfig.php
@@ -15,9 +15,11 @@ use Cycle\Database\Config\ProvidesSourceString;
 
 class TcpConnectionConfig extends ConnectionConfig implements ProvidesSourceString
 {
+    public int $port;
+
     /**
      * @param non-empty-string $host
-     * @param positive-int $port
+     * @param positive-int|non-empty-string $port
      * @param non-empty-string $database
      * @param non-empty-string|null $charset
      * @param non-empty-string|null $user
@@ -27,12 +29,14 @@ class TcpConnectionConfig extends ConnectionConfig implements ProvidesSourceStri
     public function __construct(
         public string $database,
         public string $host = 'localhost',
-        public int $port = 3307,
+        int|string $port = 3307,
         public ?string $charset = null,
         ?string $user = null,
         ?string $password = null,
         array $options = [],
     ) {
+        $this->port = (int) $port;
+
         parent::__construct($user, $password, $options);
     }
 

--- a/src/Config/MySQL/TcpConnectionConfig.php
+++ b/src/Config/MySQL/TcpConnectionConfig.php
@@ -19,7 +19,7 @@ class TcpConnectionConfig extends ConnectionConfig implements ProvidesSourceStri
 
     /**
      * @param non-empty-string $host
-     * @param non-empty-string|positive-int $port
+     * @param numeric-string|positive-int $port
      * @param non-empty-string $database
      * @param non-empty-string|null $charset
      * @param non-empty-string|null $user

--- a/src/Config/MySQL/TcpConnectionConfig.php
+++ b/src/Config/MySQL/TcpConnectionConfig.php
@@ -19,7 +19,7 @@ class TcpConnectionConfig extends ConnectionConfig implements ProvidesSourceStri
 
     /**
      * @param non-empty-string $host
-     * @param positive-int|non-empty-string $port
+     * @param non-empty-string|positive-int $port
      * @param non-empty-string $database
      * @param non-empty-string|null $charset
      * @param non-empty-string|null $user

--- a/src/Config/Postgres/TcpConnectionConfig.php
+++ b/src/Config/Postgres/TcpConnectionConfig.php
@@ -20,7 +20,7 @@ class TcpConnectionConfig extends ConnectionConfig implements ProvidesSourceStri
     /**
      * @param non-empty-string $database
      * @param non-empty-string $host
-     * @param non-empty-string|positive-int $port
+     * @param numeric-string|positive-int $port
      * @param non-empty-string|null $user
      * @param non-empty-string|null $password
      * @param array $options

--- a/src/Config/Postgres/TcpConnectionConfig.php
+++ b/src/Config/Postgres/TcpConnectionConfig.php
@@ -15,6 +15,9 @@ use Cycle\Database\Config\ProvidesSourceString;
 
 class TcpConnectionConfig extends ConnectionConfig implements ProvidesSourceString
 {
+    /**
+     * @var positive-int
+     */
     public int $port;
 
     /**

--- a/src/Config/Postgres/TcpConnectionConfig.php
+++ b/src/Config/Postgres/TcpConnectionConfig.php
@@ -15,10 +15,12 @@ use Cycle\Database\Config\ProvidesSourceString;
 
 class TcpConnectionConfig extends ConnectionConfig implements ProvidesSourceString
 {
+    public int $port;
+
     /**
      * @param non-empty-string $database
      * @param non-empty-string $host
-     * @param positive-int $port
+     * @param positive-int|non-empty-string $port
      * @param non-empty-string|null $user
      * @param non-empty-string|null $password
      * @param array $options
@@ -26,11 +28,13 @@ class TcpConnectionConfig extends ConnectionConfig implements ProvidesSourceStri
     public function __construct(
         public string $database,
         public string $host = 'localhost',
-        public int $port = 5432,
+        int|string $port = 5432,
         ?string $user = null,
         ?string $password = null,
         array $options = []
     ) {
+        $this->port = (int) $port;
+
         parent::__construct($user, $password, $options);
     }
 

--- a/src/Config/Postgres/TcpConnectionConfig.php
+++ b/src/Config/Postgres/TcpConnectionConfig.php
@@ -20,7 +20,7 @@ class TcpConnectionConfig extends ConnectionConfig implements ProvidesSourceStri
     /**
      * @param non-empty-string $database
      * @param non-empty-string $host
-     * @param positive-int|non-empty-string $port
+     * @param non-empty-string|positive-int $port
      * @param non-empty-string|null $user
      * @param non-empty-string|null $password
      * @param array $options

--- a/src/Config/SQLServer/TcpConnectionConfig.php
+++ b/src/Config/SQLServer/TcpConnectionConfig.php
@@ -21,10 +21,12 @@ use Cycle\Database\Config\PDOConnectionConfig;
  */
 class TcpConnectionConfig extends ConnectionConfig implements ProvidesSourceString
 {
+    public ?int $port = null;
+
     /**
      * @param non-empty-string $database The name of the database.
      * @param non-empty-string $host Database connection host.
-     * @param positive-int|null $port Database connection port.
+     * @param positive-int|non-empty-string|null $port Database connection port.
      * @param non-empty-string|null $app The application name used in tracing.
      * @param bool|null $pooling Specifies whether the connection is assigned from a
      *        connection pool ({@see true}) or not ({@see false}).
@@ -56,7 +58,7 @@ class TcpConnectionConfig extends ConnectionConfig implements ProvidesSourceStri
     public function __construct(
         public string $database,
         public string $host = 'localhost',
-        public ?int $port = null,
+        int|string|null $port = null,
         public ?string $app = null,
         public ?bool $pooling = null,
         public ?bool $encrypt = null,
@@ -73,6 +75,8 @@ class TcpConnectionConfig extends ConnectionConfig implements ProvidesSourceStri
         ?string $password = null,
         array $options = []
     ) {
+        $this->port = $port !== null ? (int) $port : null;
+
         parent::__construct($user, $password, $options);
     }
 

--- a/src/Config/SQLServer/TcpConnectionConfig.php
+++ b/src/Config/SQLServer/TcpConnectionConfig.php
@@ -26,7 +26,7 @@ class TcpConnectionConfig extends ConnectionConfig implements ProvidesSourceStri
     /**
      * @param non-empty-string $database The name of the database.
      * @param non-empty-string $host Database connection host.
-     * @param positive-int|non-empty-string|null $port Database connection port.
+     * @param non-empty-string|positive-int|null $port Database connection port.
      * @param non-empty-string|null $app The application name used in tracing.
      * @param bool|null $pooling Specifies whether the connection is assigned from a
      *        connection pool ({@see true}) or not ({@see false}).

--- a/src/Config/SQLServer/TcpConnectionConfig.php
+++ b/src/Config/SQLServer/TcpConnectionConfig.php
@@ -21,6 +21,9 @@ use Cycle\Database\Config\PDOConnectionConfig;
  */
 class TcpConnectionConfig extends ConnectionConfig implements ProvidesSourceString
 {
+    /**
+     * @var ?positive-int
+     */
     public ?int $port = null;
 
     /**

--- a/src/Config/SQLServer/TcpConnectionConfig.php
+++ b/src/Config/SQLServer/TcpConnectionConfig.php
@@ -26,7 +26,7 @@ class TcpConnectionConfig extends ConnectionConfig implements ProvidesSourceStri
     /**
      * @param non-empty-string $database The name of the database.
      * @param non-empty-string $host Database connection host.
-     * @param non-empty-string|positive-int|null $port Database connection port.
+     * @param numeric-string|positive-int|null $port Database connection port.
      * @param non-empty-string|null $app The application name used in tracing.
      * @param bool|null $pooling Specifies whether the connection is assigned from a
      *        connection pool ({@see true}) or not ({@see false}).

--- a/tests/Database/Unit/Config/BaseConfigTest.php
+++ b/tests/Database/Unit/Config/BaseConfigTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Unit\Config;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseConfigTest extends TestCase
+{
+    public function portDataProvider(): \Traversable
+    {
+        yield [3306, 3306];
+        yield ['3306', 3306];
+        yield [0, 0];
+        yield ['foo', 0];
+    }
+}

--- a/tests/Database/Unit/Config/MySQL/TcpConnectionConfigTest.php
+++ b/tests/Database/Unit/Config/MySQL/TcpConnectionConfigTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Cycle\Database\Tests\Unit\Config\MySQL;
 
 use Cycle\Database\Config\MySQL\TcpConnectionConfig;
-use PHPUnit\Framework\TestCase;
+use Cycle\Database\Tests\Unit\Config\BaseConfigTest;
 
-final class TcpConnectionConfigTest extends TestCase
+final class TcpConnectionConfigTest extends BaseConfigTest
 {
     public function testSetState(): void
     {
@@ -34,5 +34,18 @@ final class TcpConnectionConfigTest extends TestCase
         $this->assertSame($password, $recoveredConfig->getPassword());
         $this->assertArrayHasKey($testOptionKey, $recoveredConfig->getOptions());
         $this->assertSame($testOptionValue, $recoveredConfig->getOptions()[$testOptionKey]);
+    }
+
+    /**
+     * @dataProvider portDataProvider
+     */
+    public function testPort(int|string $port, int $expected): void
+    {
+        $config = new TcpConnectionConfig(
+            database: 'database',
+            port: $port
+        );
+
+        $this->assertSame($expected, $config->port);
     }
 }

--- a/tests/Database/Unit/Config/Postgres/TcpConnectionConfigTest.php
+++ b/tests/Database/Unit/Config/Postgres/TcpConnectionConfigTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Cycle\Database\Tests\Unit\Config\Postgres;
 
 use Cycle\Database\Config\Postgres\TcpConnectionConfig;
-use PHPUnit\Framework\TestCase;
+use Cycle\Database\Tests\Unit\Config\BaseConfigTest;
 
-final class TcpConnectionConfigTest extends TestCase
+final class TcpConnectionConfigTest extends BaseConfigTest
 {
     public function testSetState(): void
     {
@@ -33,5 +33,18 @@ final class TcpConnectionConfigTest extends TestCase
         $this->assertSame($password, $recoveredConfig->getPassword());
         $this->assertArrayHasKey($testOptionKey, $recoveredConfig->getOptions());
         $this->assertSame($testOptionValue, $recoveredConfig->getOptions()[$testOptionKey]);
+    }
+
+    /**
+     * @dataProvider portDataProvider
+     */
+    public function testPort(int|string $port, int $expected): void
+    {
+        $config = new TcpConnectionConfig(
+            database: 'database',
+            port: $port
+        );
+
+        $this->assertSame($expected, $config->port);
     }
 }

--- a/tests/Database/Unit/Config/SQLServer/TcpConnectionConfigTest.php
+++ b/tests/Database/Unit/Config/SQLServer/TcpConnectionConfigTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Cycle\Database\Tests\Unit\Config\SQLServer;
 
 use Cycle\Database\Config\SQLServer\TcpConnectionConfig;
-use PHPUnit\Framework\TestCase;
+use Cycle\Database\Tests\Unit\Config\BaseConfigTest;
 
-final class TcpConnectionConfigTest extends TestCase
+final class TcpConnectionConfigTest extends BaseConfigTest
 {
     public function testSetState(): void
     {
@@ -65,5 +65,24 @@ final class TcpConnectionConfigTest extends TestCase
         $this->assertSame($password, $recoveredConfig->getPassword());
         $this->assertArrayHasKey($testOptionKey, $recoveredConfig->getOptions());
         $this->assertSame($testOptionValue, $recoveredConfig->getOptions()[$testOptionKey]);
+    }
+
+    /**
+     * @dataProvider portDataProvider
+     * @dataProvider nullPortDataProvider
+     */
+    public function testPort(int|string|null $port, ?int $expected): void
+    {
+        $config = new TcpConnectionConfig(
+            database: 'database',
+            port: $port
+        );
+
+        $this->assertSame($expected, $config->port);
+    }
+
+    public function nullPortDataProvider(): \Traversable
+    {
+        yield [null, null];
     }
 }


### PR DESCRIPTION
This will allow passing a value from **env** without casting it to an integer.

```php
'drivers' => [
    'mysql' => new Config\MySQLDriverConfig(
        connection: new Config\MySQL\TcpConnectionConfig(
            database: 'spiral',
            host: '127.0.0.1',
            port: env('DB_PORT'),
            user: 'root',
            password: 'root',
         ),
        queryCache: true
    ),
],
```