### PR TITLE
Fix example in PHPDoc for `InsertQuery::values()`

### DIFF
--- a/src/Query/InsertQuery.php
+++ b/src/Query/InsertQuery.php
@@ -68,14 +68,14 @@ class InsertQuery extends ActiveQuery
      *      "balance" => 10
      * ]);
      * $insert->columns("name", "balance")->values([
-     *     [
-     *         "name" => "Wolfy-J",
-     *         "balance" => 10
-     *     ],
-     *     [
-     *         "name" => "Ben",
-     *         "balance" => 20
-     *     ]
+     *  [
+     *      "name" => "Wolfy-J",
+     *      "balance" => 10
+     *  ],
+     *  [
+     *      "name" => "Ben",
+     *      "balance" => 20
+     *  ]
      * ]);
      */
     public function values(mixed $rowsets): self

--- a/src/Query/InsertQuery.php
+++ b/src/Query/InsertQuery.php
@@ -61,11 +61,21 @@ class InsertQuery extends ActiveQuery
      * (method parameters, array of values, array or rowsets). Columns names will be automatically
      * fetched (if not already specified) from first provided rowset based on rowset keys.
      *
-     * Example:
+     * Examples:
      * $insert->columns("name", "balance")->values("Wolfy-J", 10);
      * $insert->values([
      *      "name" => "Wolfy-J",
      *      "balance" => 10
+     * ]);
+     * $insert->columns("name", "balance")->values([
+     *     [
+     *         "name" => "Wolfy-J",
+     *         "balance" => 10
+     *     ],
+     *     [
+     *         "name" => "Ben",
+     *         "balance" => 20
+     *     ]
      * ]);
      */
     public function values(mixed $rowsets): self

--- a/src/Query/InsertQuery.php
+++ b/src/Query/InsertQuery.php
@@ -61,21 +61,11 @@ class InsertQuery extends ActiveQuery
      * (method parameters, array of values, array or rowsets). Columns names will be automatically
      * fetched (if not already specified) from first provided rowset based on rowset keys.
      *
-     * Examples:
+     * Example:
      * $insert->columns("name", "balance")->values("Wolfy-J", 10);
      * $insert->values([
      *      "name" => "Wolfy-J",
      *      "balance" => 10
-     * ]);
-     * $insert->values([
-     *  [
-     *      "name" => "Wolfy-J",
-     *      "balance" => 10
-     *  ],
-     *  [
-     *      "name" => "Ben",
-     *      "balance" => 20
-     *  ]
      * ]);
      */
     public function values(mixed $rowsets): self


### PR DESCRIPTION
This no longer works. Is there any alternative with rowsets in form of associative arrays?