### PR TITLE
Add index creation property to the AbstractForeignKey class

### DIFF
--- a/src/Driver/MySQL/Schema/MySQLForeignKey.php
+++ b/src/Driver/MySQL/Schema/MySQLForeignKey.php
@@ -36,7 +36,7 @@ class MySQLForeignKey extends AbstractForeignKey
         return $reference;
     }
 
-    public function shouldCreateIndex(): bool
+    public function hasIndex(): bool
     {
         return true;
     }

--- a/src/Driver/MySQL/Schema/MySQLForeignKey.php
+++ b/src/Driver/MySQL/Schema/MySQLForeignKey.php
@@ -35,4 +35,9 @@ class MySQLForeignKey extends AbstractForeignKey
 
         return $reference;
     }
+
+    public function shouldCreateIndex(): bool
+    {
+        return true;
+    }
 }

--- a/src/Schema/AbstractForeignKey.php
+++ b/src/Schema/AbstractForeignKey.php
@@ -188,8 +188,13 @@ abstract class AbstractForeignKey implements ForeignKeyInterface, ElementInterfa
 
     public function compare(self $initial): bool
     {
+        // exclude `createIndex` from comparing
+        $current = clone $this;
+        $initial = clone $initial;
+        unset($current->createIndex, $initial->createIndex);
+
         // soft compare
-        return $this == clone $initial;
+        return $current == $initial;
     }
 
     /**

--- a/src/Schema/AbstractForeignKey.php
+++ b/src/Schema/AbstractForeignKey.php
@@ -23,6 +23,8 @@ abstract class AbstractForeignKey implements ForeignKeyInterface, ElementInterfa
 {
     use ElementTrait;
 
+    protected const EXCLUDE_FROM_COMPARE = ['createIndex'];
+
     /**
      * Local column name (key name).
      */
@@ -188,13 +190,23 @@ abstract class AbstractForeignKey implements ForeignKeyInterface, ElementInterfa
 
     public function compare(self $initial): bool
     {
-        // exclude `createIndex` from comparing
-        $current = clone $this;
-        $initial = clone $initial;
-        unset($current->createIndex, $initial->createIndex);
-
         // soft compare
-        return $current == $initial;
+        if ($this == clone $initial) {
+            return true;
+        }
+        $initialVars = \get_object_vars($initial);
+
+        foreach (\get_object_vars($this) as $name => $value) {
+            if (\in_array($name, static::EXCLUDE_FROM_COMPARE, true)) {
+                continue;
+            }
+
+            if ($value !== $initialVars[$name]) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Schema/AbstractForeignKey.php
+++ b/src/Schema/AbstractForeignKey.php
@@ -23,7 +23,7 @@ abstract class AbstractForeignKey implements ForeignKeyInterface, ElementInterfa
 {
     use ElementTrait;
 
-    protected const EXCLUDE_FROM_COMPARE = ['createIndex'];
+    protected const EXCLUDE_FROM_COMPARE = ['index'];
 
     /**
      * Local column name (key name).
@@ -53,7 +53,7 @@ abstract class AbstractForeignKey implements ForeignKeyInterface, ElementInterfa
     /**
      * Create an index or not.
      */
-    protected bool $createIndex = true;
+    protected bool $index = true;
 
     /**
      * @psalm-param non-empty-string $table
@@ -155,14 +155,16 @@ abstract class AbstractForeignKey implements ForeignKeyInterface, ElementInterfa
         return $this;
     }
 
-    public function withoutIndex(): void
+    public function setIndex(bool $index = true): static
     {
-        $this->createIndex = false;
+        $this->index = $index;
+
+        return $this;
     }
 
-    public function shouldCreateIndex(): bool
+    public function hasIndex(): bool
     {
-        return $this->createIndex;
+        return $this->index;
     }
 
     /**
@@ -190,22 +192,14 @@ abstract class AbstractForeignKey implements ForeignKeyInterface, ElementInterfa
 
     public function compare(self $initial): bool
     {
-        // soft compare
-        if ($this == clone $initial) {
-            return true;
-        }
-        $initialVars = \get_object_vars($initial);
-
-        foreach (\get_object_vars($this) as $name => $value) {
+        foreach ($this as $name => $value) {
             if (\in_array($name, static::EXCLUDE_FROM_COMPARE, true)) {
                 continue;
             }
-
-            if ($value !== $initialVars[$name]) {
+            if ($value !== $initial->$name) {
                 return false;
             }
         }
-
         return true;
     }
 

--- a/src/Schema/AbstractForeignKey.php
+++ b/src/Schema/AbstractForeignKey.php
@@ -49,6 +49,11 @@ abstract class AbstractForeignKey implements ForeignKeyInterface, ElementInterfa
     protected string $updateRule = self::NO_ACTION;
 
     /**
+     * Create an index or not.
+     */
+    protected bool $createIndex = true;
+
+    /**
      * @psalm-param non-empty-string $table
      *
      * @param string $tablePrefix
@@ -146,6 +151,16 @@ abstract class AbstractForeignKey implements ForeignKeyInterface, ElementInterfa
         $this->updateRule = strtoupper($rule);
 
         return $this;
+    }
+
+    public function withoutIndex(): void
+    {
+        $this->createIndex = false;
+    }
+
+    public function shouldCreateIndex(): bool
+    {
+        return $this->createIndex;
     }
 
     /**

--- a/src/Schema/AbstractTable.php
+++ b/src/Schema/AbstractTable.php
@@ -447,7 +447,7 @@ abstract class AbstractTable implements TableInterface, ElementInterface
         $this->current->registerForeignKey($foreign);
 
         //Let's ensure index existence to performance and compatibility reasons
-        $indexCreate ? $this->index($columns) : $foreign->withoutIndex();
+        $indexCreate ? $this->index($columns) : $foreign->setIndex(false);
 
         return $foreign;
     }

--- a/src/Schema/AbstractTable.php
+++ b/src/Schema/AbstractTable.php
@@ -422,7 +422,7 @@ abstract class AbstractTable implements TableInterface, ElementInterface
      *
      * @throws SchemaException
      */
-    public function foreignKey(array $columns): AbstractForeignKey
+    public function foreignKey(array $columns, bool $indexCreate = true): AbstractForeignKey
     {
         foreach ($columns as $column) {
             $this->hasColumn($column) or throw new SchemaException(
@@ -447,7 +447,9 @@ abstract class AbstractTable implements TableInterface, ElementInterface
         $this->current->registerForeignKey($foreign);
 
         //Let's ensure index existence to performance and compatibility reasons
-        $this->index($columns);
+        if ($indexCreate) {
+            $this->index($columns);
+        }
 
         return $foreign;
     }

--- a/src/Schema/AbstractTable.php
+++ b/src/Schema/AbstractTable.php
@@ -447,9 +447,7 @@ abstract class AbstractTable implements TableInterface, ElementInterface
         $this->current->registerForeignKey($foreign);
 
         //Let's ensure index existence to performance and compatibility reasons
-        if ($indexCreate) {
-            $this->index($columns);
-        }
+        $indexCreate ? $this->index($columns) : $foreign->withoutIndex();
 
         return $foreign;
     }

--- a/tests/Database/Functional/Driver/Common/Schema/ForeignKeysTest.php
+++ b/tests/Database/Functional/Driver/Common/Schema/ForeignKeysTest.php
@@ -315,21 +315,4 @@ abstract class ForeignKeysTest extends BaseTest
         $this->assertTrue($this->schema('schema')->hasForeignKey(['external_id']));
         $this->assertTrue($this->schema('schema')->hasIndex(['external_id']));
     }
-
-    public function testCreateWithoutIndex(): void
-    {
-        $schema = $this->schema('schema');
-        $this->assertFalse($schema->exists());
-        $this->assertTrue($this->sampleSchema('external')->exists());
-
-        $schema->primary('id');
-        $schema->integer('external_id');
-        $schema->foreignKey(['external_id'], false)->references('external', ['id']);
-
-        $schema->save(Handler::DO_ALL);
-
-        $this->assertSameAsInDB($schema);
-        $this->assertTrue($this->schema('schema')->hasForeignKey(['external_id']));
-        $this->assertFalse($this->schema('schema')->hasIndex(['external_id']));
-    }
 }

--- a/tests/Database/Functional/Driver/Common/Schema/ForeignKeysTest.php
+++ b/tests/Database/Functional/Driver/Common/Schema/ForeignKeysTest.php
@@ -298,4 +298,38 @@ abstract class ForeignKeysTest extends BaseTest
 
         $this->assertSameAsInDB($schema);
     }
+
+    public function testCreateWithIndex(): void
+    {
+        $schema = $this->schema('schema');
+        $this->assertFalse($schema->exists());
+        $this->assertTrue($this->sampleSchema('external')->exists());
+
+        $schema->primary('id');
+        $schema->integer('external_id');
+        $schema->foreignKey(['external_id'])->references('external', ['id']);
+
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+        $this->assertTrue($this->schema('schema')->hasForeignKey(['external_id']));
+        $this->assertTrue($this->schema('schema')->hasIndex(['external_id']));
+    }
+
+    public function testCreateWithoutIndex(): void
+    {
+        $schema = $this->schema('schema');
+        $this->assertFalse($schema->exists());
+        $this->assertTrue($this->sampleSchema('external')->exists());
+
+        $schema->primary('id');
+        $schema->integer('external_id');
+        $schema->foreignKey(['external_id'], false)->references('external', ['id']);
+
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+        $this->assertTrue($this->schema('schema')->hasForeignKey(['external_id']));
+        $this->assertFalse($this->schema('schema')->hasIndex(['external_id']));
+    }
 }

--- a/tests/Database/Functional/Driver/Postgres/Schema/ForeignKeysTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Schema/ForeignKeysTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Database\Tests\Functional\Driver\Postgres\Schema;
 
 // phpcs:ignore
+use Cycle\Database\Driver\Handler;
 use Cycle\Database\Tests\Functional\Driver\Common\Schema\ForeignKeysTest as CommonClass;
 
 /**
@@ -14,4 +15,21 @@ use Cycle\Database\Tests\Functional\Driver\Common\Schema\ForeignKeysTest as Comm
 class ForeignKeysTest extends CommonClass
 {
     public const DRIVER = 'postgres';
+
+    public function testCreateWithoutIndex(): void
+    {
+        $schema = $this->schema('schema');
+        $this->assertFalse($schema->exists());
+        $this->assertTrue($this->sampleSchema('external')->exists());
+
+        $schema->primary('id');
+        $schema->integer('external_id');
+        $schema->foreignKey(['external_id'], false)->references('external', ['id']);
+
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+        $this->assertTrue($this->schema('schema')->hasForeignKey(['external_id']));
+        $this->assertFalse($this->schema('schema')->hasIndex(['external_id']));
+    }
 }

--- a/tests/Database/Functional/Driver/SQLServer/Schema/ForeignKeysTest.php
+++ b/tests/Database/Functional/Driver/SQLServer/Schema/ForeignKeysTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Database\Tests\Functional\Driver\SQLServer\Schema;
 
 // phpcs:ignore
+use Cycle\Database\Driver\Handler;
 use Cycle\Database\Tests\Functional\Driver\Common\Schema\ForeignKeysTest as CommonClass;
 
 /**
@@ -14,4 +15,21 @@ use Cycle\Database\Tests\Functional\Driver\Common\Schema\ForeignKeysTest as Comm
 class ForeignKeysTest extends CommonClass
 {
     public const DRIVER = 'sqlserver';
+
+    public function testCreateWithoutIndex(): void
+    {
+        $schema = $this->schema('schema');
+        $this->assertFalse($schema->exists());
+        $this->assertTrue($this->sampleSchema('external')->exists());
+
+        $schema->primary('id');
+        $schema->integer('external_id');
+        $schema->foreignKey(['external_id'], false)->references('external', ['id']);
+
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+        $this->assertTrue($this->schema('schema')->hasForeignKey(['external_id']));
+        $this->assertFalse($this->schema('schema')->hasIndex(['external_id']));
+    }
 }

--- a/tests/Database/Functional/Driver/SQLite/Schema/ForeignKeysTest.php
+++ b/tests/Database/Functional/Driver/SQLite/Schema/ForeignKeysTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Database\Tests\Functional\Driver\SQLite\Schema;
 
 // phpcs:ignore
+use Cycle\Database\Driver\Handler;
 use Cycle\Database\Tests\Functional\Driver\Common\Schema\ForeignKeysTest as CommonClass;
 
 /**
@@ -14,4 +15,21 @@ use Cycle\Database\Tests\Functional\Driver\Common\Schema\ForeignKeysTest as Comm
 class ForeignKeysTest extends CommonClass
 {
     public const DRIVER = 'sqlite';
+
+    public function testCreateWithoutIndex(): void
+    {
+        $schema = $this->schema('schema');
+        $this->assertFalse($schema->exists());
+        $this->assertTrue($this->sampleSchema('external')->exists());
+
+        $schema->primary('id');
+        $schema->integer('external_id');
+        $schema->foreignKey(['external_id'], false)->references('external', ['id']);
+
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+        $this->assertTrue($this->schema('schema')->hasForeignKey(['external_id']));
+        $this->assertFalse($this->schema('schema')->hasIndex(['external_id']));
+    }
 }

--- a/tests/Database/Unit/Schema/AbstractForeignKeyTest.php
+++ b/tests/Database/Unit/Schema/AbstractForeignKeyTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Unit\Schema;
+
+use Cycle\Database\Driver\MySQL\Schema\MySQLForeignKey;
+use Cycle\Database\Schema\AbstractForeignKey;
+use PHPUnit\Framework\TestCase;
+
+final class AbstractForeignKeyTest extends TestCase
+{
+    public function testDefaultCreateIndex(): void
+    {
+        $fk = new class ('foo', 'bar', 'baz') extends AbstractForeignKey {};
+
+        $this->assertTrue($fk->shouldCreateIndex());
+    }
+
+    public function testWithoutIndex(): void
+    {
+        $fk = new class ('foo', 'bar', 'baz') extends AbstractForeignKey {};
+        $fk->withoutIndex();
+
+        $this->assertFalse($fk->shouldCreateIndex());
+    }
+
+    public function testMySQLShouldAlwaysCreateIndex(): void
+    {
+        $fk = new MySQLForeignKey('foo', 'bar', 'baz');
+        $fk->withoutIndex();
+
+        $this->assertTrue($fk->shouldCreateIndex());
+    }
+}

--- a/tests/Database/Unit/Schema/AbstractForeignKeyTest.php
+++ b/tests/Database/Unit/Schema/AbstractForeignKeyTest.php
@@ -14,22 +14,22 @@ final class AbstractForeignKeyTest extends TestCase
     {
         $fk = new class ('foo', 'bar', 'baz') extends AbstractForeignKey {};
 
-        $this->assertTrue($fk->shouldCreateIndex());
+        $this->assertTrue($fk->hasIndex());
     }
 
     public function testWithoutIndex(): void
     {
         $fk = new class ('foo', 'bar', 'baz') extends AbstractForeignKey {};
-        $fk->withoutIndex();
+        $fk->setIndex(false);
 
-        $this->assertFalse($fk->shouldCreateIndex());
+        $this->assertFalse($fk->hasIndex());
     }
 
     public function testMySQLShouldAlwaysCreateIndex(): void
     {
         $fk = new MySQLForeignKey('foo', 'bar', 'baz');
-        $fk->withoutIndex();
+        $fk->setIndex(false);
 
-        $this->assertTrue($fk->shouldCreateIndex());
+        $this->assertTrue($fk->hasIndex());
     }
 }


### PR DESCRIPTION
Issue: #113 

Added the ability to disable the creation of the index. But keep in mind that MySQL creates an index automatically and it is required for foreign keys:
https://dev.mysql.com/doc/refman/8.0/en/create-table-foreign-keys.html

I think this needs to be described in our documentation.