### PR TITLE
Add JSON type for MySQL

### DIFF
--- a/src/Driver/MySQL/MySQLHandler.php
+++ b/src/Driver/MySQL/MySQLHandler.php
@@ -133,11 +133,11 @@ class MySQLHandler extends Handler
             $column->getDefaultValue() !== null
             && \in_array(
                 $column->getAbstractType(),
-                ['text', 'tinyText', 'longText', 'blob', 'tinyBlob', 'longBlob']
+                ['text', 'tinyText', 'longText', 'blob', 'tinyBlob', 'longBlob', 'json']
             )
         ) {
             throw new MySQLException(
-                "Column {$column} of type text/blob can not have non empty default value"
+                "Column {$column} of type text/blob/json can not have non empty default value"
             );
         }
     }

--- a/src/Driver/MySQL/Schema/MySQLColumn.php
+++ b/src/Driver/MySQL/Schema/MySQLColumn.php
@@ -98,7 +98,7 @@ class MySQLColumn extends AbstractColumn
         'longBinary'  => 'longblob',
 
         //Additional types
-        'json'        => 'text',
+        'json'        => 'json',
         'uuid'        => ['type' => 'varchar', 'size' => 36],
     ];
 
@@ -126,6 +126,7 @@ class MySQLColumn extends AbstractColumn
         'binary'      => ['blob', 'binary', 'varbinary'],
         'tinyBinary'  => ['tinyblob'],
         'longBinary'  => ['longblob'],
+        'json'        => ['json'],
     ];
 
     /**
@@ -139,6 +140,7 @@ class MySQLColumn extends AbstractColumn
         'blob',
         'tinyblob',
         'longblob',
+        'json',
     ];
 
     /**

--- a/tests/Database/Functional/Driver/Common/Schema/DefaultValueTest.php
+++ b/tests/Database/Functional/Driver/Common/Schema/DefaultValueTest.php
@@ -302,6 +302,48 @@ abstract class DefaultValueTest extends BaseTest
         $this->assertTrue($schema->column('target')->compare($column));
     }
 
+    public function testJsonDefaultValueEmpty(): void
+    {
+        $schema = $this->schema('table');
+        $this->assertFalse($schema->exists());
+
+        //This WILL fail in MySQL!
+        $column = $schema->json('target')->defaultValue('');
+
+        $schema->save();
+        $schema = $this->schema('table');
+        $this->assertTrue($schema->exists());
+        $this->assertTrue($schema->column('target')->compare($column));
+    }
+
+    public function testJsonDefaultValueNull(): void
+    {
+        $schema = $this->schema('table');
+        $this->assertFalse($schema->exists());
+
+        $column = $schema->json('target')->defaultValue(null);
+
+        $schema->save();
+        $schema = $this->schema('table');
+        $this->assertTrue($schema->exists());
+        $this->assertTrue($schema->column('target')->compare($column));
+        $this->assertNull($schema->column('target')->getDefaultValue());
+    }
+
+    public function testJsonDefaultValueString(): void
+    {
+        $schema = $this->schema('table');
+        $this->assertFalse($schema->exists());
+
+        //This WILL fail in MySQL!
+        $column = $schema->json('target')->defaultValue('non empty');
+
+        $schema->save();
+        $schema = $this->schema('table');
+        $this->assertTrue($schema->exists());
+        $this->assertTrue($schema->column('target')->compare($column));
+    }
+
     public function testEnumDefaultValueNull(): void
     {
         $schema = $this->schema('table');

--- a/tests/Database/Functional/Driver/MySQL/Schema/CreateTableTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Schema/CreateTableTest.php
@@ -14,4 +14,25 @@ use Cycle\Database\Tests\Functional\Driver\Common\Schema\CreateTableTest as Comm
 class CreateTableTest extends CommonClass
 {
     public const DRIVER = 'mysql';
+
+    public function testMultipleColumnsWithJson(): void
+    {
+        $schema = $this->schema('table');
+        $this->assertFalse($schema->exists());
+
+        $schema->primary('id');
+        $schema->string('name');
+        $schema->enum('status', ['active', 'disabled']);
+        $schema->float('balance')->defaultValue(0);
+        $schema->json('data');
+
+        $schema->save();
+
+        $schema = $this->schema('table');
+        $this->assertTrue($schema->exists());
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame(['active', 'disabled'], $schema->column('status')->getEnumValues());
+        $this->assertSame('json', $schema->column('data')->getAbstractType());
+    }
 }

--- a/tests/Database/Functional/Driver/MySQL/Schema/DefaultValueTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Schema/DefaultValueTest.php
@@ -18,14 +18,28 @@ class DefaultValueTest extends CommonClass
     public function testTextDefaultValueString(): void
     {
         $this->expectException(\Cycle\Database\Driver\MySQL\Exception\MySQLException::class);
-        $this->expectExceptionMessage('Column table.target of type text/blob can not have non empty default value');
+        $this->expectExceptionMessage('Column table.target of type text/blob/json can not have non empty default value');
         parent::testTextDefaultValueString();
     }
 
     public function testTextDefaultValueEmpty(): void
     {
         $this->expectException(\Cycle\Database\Driver\MySQL\Exception\MySQLException::class);
-        $this->expectExceptionMessage('Column table.target of type text/blob can not have non empty default value');
+        $this->expectExceptionMessage('Column table.target of type text/blob/json can not have non empty default value');
         parent::testTextDefaultValueEmpty();
+    }
+
+    public function testJsonDefaultValueString(): void
+    {
+        $this->expectException(\Cycle\Database\Driver\MySQL\Exception\MySQLException::class);
+        $this->expectExceptionMessage('Column table.target of type text/blob/json can not have non empty default value');
+        parent::testJsonDefaultValueString();
+    }
+
+    public function testJsonDefaultValueEmpty(): void
+    {
+        $this->expectException(\Cycle\Database\Driver\MySQL\Exception\MySQLException::class);
+        $this->expectExceptionMessage('Column table.target of type text/blob/json can not have non empty default value');
+        parent::testJsonDefaultValueEmpty();
     }
 }


### PR DESCRIPTION
Issue: https://github.com/cycle/database/issues/39

Adding support of JSON data type for MySQL driver since MySQL [5.7](https://dev.mysql.com/doc/refman/5.7/en/json.html) and [8.0](https://dev.mysql.com/doc/refman/8.0/en/json.html) supports this data type.
