### PR TITLE
fix type strictness in TokenTrait

### DIFF
--- a/src/Query/Traits/TokenTrait.php
+++ b/src/Query/Traits/TokenTrait.php
@@ -172,6 +172,7 @@ trait TokenTrait
                 continue;
             }
 
+            $key = (string)$key;
             $token = strtoupper($key);
 
             // Grouping identifier (@OR, @AND), MongoDB like style


### PR DESCRIPTION
Fix 
```
TypeError: strtoupper(): Argument #1 ($string) must be of type string, int given
vendor\cycle\database\src\Query\Traits\TokenTrait.php:175
```


I'm not sure about that fix because it might be related with building for bad query. After the fix I get some think like this:
![{C7935317-2937-4538-A7CE-B0C5FB8408EE}](https://github.com/cycle/database/assets/4152481/753070ef-6a7c-49b0-bb2a-3ce2a9d86b61)

---

Upd:

The bad query produces Cycle ORM Scope:
```php
final class UnexpiredTokenScope implements ScopeInterface
{
    public function apply(QueryBuilder $query): void
    {
        $query->andWhere(['@OR' => [
            [Token::F_EXPIRES_AT, '=', new Parameter(null)],
            [Token::F_EXPIRES_AT, '>', new \DateTimeImmutable()],
        ]]);
    }
}
```

That query code can be replaced with this one:

```php
        $query->andWhere(function (QueryBuilder $query) {
            $query->where(Token::F_EXPIRES_AT, '=', new Parameter(null))
                ->orWhere(Token::F_EXPIRES_AT, '>', new \DateTimeImmutable());
        });
```

But we need to research if the origin code was correct. If yes - need to fix QueryBuilder