### PR TITLE
Fixing Postgres schema after reconnect

### DIFF
--- a/src/Driver/Postgres/PostgresDriver.php
+++ b/src/Driver/Postgres/PostgresDriver.php
@@ -216,13 +216,8 @@ class PostgresDriver extends Driver
         // TODO Should be moved into driver settings.
         $pdo->exec("SET NAMES 'UTF-8'");
 
-        // TODO May be redundant?
-        //      Search schemas list can not be empty.
-        if ($this->searchPath !== []) {
-            $schema = '"' . implode('", "', $this->searchPath) . '"';
-            $pdo->exec("SET search_path TO {$schema}");
-            $this->searchPath = [];
-        }
+        $schema = '"' . implode('", "', $this->searchPath) . '"';
+        $pdo->exec("SET search_path TO {$schema}");
 
         return $pdo;
     }

--- a/tests/Database/Functional/Driver/Common/BaseTest.php
+++ b/tests/Database/Functional/Driver/Common/BaseTest.php
@@ -45,8 +45,6 @@ abstract class BaseTest extends TestCase
     }
 
     /**
-     * @param array{readonly: bool} $driverConfig
-     *
      * @return DriverInterface
      */
     private function getDriver(array $driverConfig = [], array $connectionConfig = []): DriverInterface
@@ -84,18 +82,15 @@ abstract class BaseTest extends TestCase
 
     private function applyDriverOptions(DriverConfig $config, array $options): void
     {
-        // Add readonly options support
-        if (isset($options['readonly']) && $options['readonly'] === true) {
-            $config->readonly = true;
-        }
-
-        if (isset($options['withDatetimeMicroseconds']) && $options['withDatetimeMicroseconds'] === true) {
-            $config->options['withDatetimeMicroseconds'] = true;
+        foreach ($options as $key => $value) {
+            if ($key === 'options') {
+                $value += $config->options;
+            }
+            $config->$key = $value;
         }
     }
 
     /**
-     * @param array{readonly: bool} $driverConfig
      * @param array $connectionConfig
      *
      * @return Database

--- a/tests/Database/Functional/Driver/MySQL/Query/InsertQueryTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Query/InsertQueryTest.php
@@ -37,18 +37,25 @@ class InsertQueryTest extends CommonClass
 
     public function testInsertMicroseconds(): void
     {
-        $schema = $this->schema(table: 'with_microseconds', driverConfig: ['withDatetimeMicroseconds' => true]);
+        $schema = $this->schema(
+            table: 'with_microseconds',
+            driverConfig: ['options' => ['withDatetimeMicroseconds' => true]]
+        );
         $schema->primary('id');
         $schema->datetime('datetime', 6);
         $schema->save();
 
         $expected = new \DateTimeImmutable();
 
-        $id = $this->db(driverConfig: ['withDatetimeMicroseconds' => true])->insert('with_microseconds')->values([
+        $id = $this->db(
+            driverConfig: ['options' => ['withDatetimeMicroseconds' => true]]
+        )->insert('with_microseconds')->values([
             'datetime' => $expected,
         ])->run();
 
-        $result = $this->db(driverConfig: ['withDatetimeMicroseconds' => true])->select('datetime')
+        $result = $this->db(
+            driverConfig: ['options' => ['withDatetimeMicroseconds' => true]]
+        )->select('datetime')
             ->from('with_microseconds')
             ->where('id', $id)
             ->run()

--- a/tests/Database/Functional/Driver/Postgres/Driver/DriverTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Driver/DriverTest.php
@@ -14,4 +14,18 @@ use Cycle\Database\Tests\Functional\Driver\Common\Driver\DriverTest as CommonCla
 class DriverTest extends CommonClass
 {
     public const DRIVER = 'postgres';
+
+    public function testSchemaPathAfterReconnect(): void
+    {
+        $db = $this->db(driverConfig: ['schema' => ['custom']]);
+
+        $ref = new \ReflectionProperty($db->getDriver(), 'searchPath');
+
+        $this->assertSame(['custom'], $ref->getValue($db->getDriver()));
+
+        $db->getDriver()->disconnect();
+        $db->getDriver()->connect();
+
+        $this->assertSame(['custom'], $ref->getValue($db->getDriver()));
+    }
 }

--- a/tests/Database/Functional/Driver/Postgres/Driver/DriverTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Driver/DriverTest.php
@@ -20,6 +20,7 @@ class DriverTest extends CommonClass
         $db = $this->db(driverConfig: ['schema' => ['custom']]);
 
         $ref = new \ReflectionProperty($db->getDriver(), 'searchPath');
+        $ref->setAccessible(true);
 
         $this->assertSame(['custom'], $ref->getValue($db->getDriver()));
 

--- a/tests/Database/Functional/Driver/Postgres/Query/InsertQueryTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Query/InsertQueryTest.php
@@ -128,18 +128,25 @@ class InsertQueryTest extends CommonClass
 
     public function testInsertMicroseconds(): void
     {
-        $schema = $this->schema(table: 'with_microseconds', driverConfig: ['withDatetimeMicroseconds' => true]);
+        $schema = $this->schema(
+            table: 'with_microseconds',
+            driverConfig: ['options' => ['withDatetimeMicroseconds' => true]]
+        );
         $schema->primary('id');
         $schema->datetime('datetime', 6);
         $schema->save();
 
         $expected = new \DateTimeImmutable();
 
-        $id = $this->db(driverConfig: ['withDatetimeMicroseconds' => true])->insert('with_microseconds')->values([
+        $id = $this->db(
+            driverConfig: ['options' => ['withDatetimeMicroseconds' => true]]
+        )->insert('with_microseconds')->values([
             'datetime' => $expected,
         ])->run();
 
-        $result = $this->db(driverConfig: ['withDatetimeMicroseconds' => true])->select('datetime')
+        $result = $this->db(
+            driverConfig: ['options' => ['withDatetimeMicroseconds' => true]]
+        )->select('datetime')
             ->from('with_microseconds')
             ->where('id', $id)
             ->run()

--- a/tests/Database/Functional/Driver/SQLite/Query/InsertQueryTest.php
+++ b/tests/Database/Functional/Driver/SQLite/Query/InsertQueryTest.php
@@ -61,18 +61,25 @@ UNION ALL SELECT ?, ?',
 
     public function testInsertMicroseconds(): void
     {
-        $schema = $this->schema(table: 'with_microseconds', driverConfig: ['withDatetimeMicroseconds' => true]);
+        $schema = $this->schema(
+            table: 'with_microseconds',
+            driverConfig: ['options' => ['withDatetimeMicroseconds' => true]]
+        );
         $schema->primary('id');
         $schema->datetime('datetime', 6);
         $schema->save();
 
         $expected = new \DateTimeImmutable();
 
-        $id = $this->db(driverConfig: ['withDatetimeMicroseconds' => true])->insert('with_microseconds')->values([
+        $id = $this->db(
+            driverConfig: ['options' => ['withDatetimeMicroseconds' => true]]
+        )->insert('with_microseconds')->values([
             'datetime' => $expected,
         ])->run();
 
-        $result = $this->db(driverConfig: ['withDatetimeMicroseconds' => true])->select('datetime')
+        $result = $this->db(
+            driverConfig: ['options' => ['withDatetimeMicroseconds' => true]]
+        )->select('datetime')
             ->from('with_microseconds')
             ->where('id', $id)
             ->run()


### PR DESCRIPTION
https://discord.com/channels/538114875570913290/1125347438505508904

Property **$this->searchPath** can't be cleared.
If clear this property, the query **SET search_path TO {$schema}** will not be executed when reconnecting.