### PR TITLE
Add `enableForeignKeyConstraints` and `disableForeignKeyConstraints` methods

### DIFF
--- a/.github/workflows/ci-mssql.yml
+++ b/.github/workflows/ci-mssql.yml
@@ -28,7 +28,7 @@ jobs:
             extensions: pdo, pdo_sqlsrv
             mssql: 'server:2019-latest'
           - php: '8.1'
-            extensions: pdo, pdo_sqlsrv-5.10.0beta2
+            extensions: pdo, pdo_sqlsrv
             mssql: 'server:2019-latest'
 
     services:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           coverage: pcov
           tools: pecl
-          extensions: mbstring, pdo, pdo_sqlite, pdo_pgsql, pdo_sqlsrv-5.10.0beta2, pdo_mysql
+          extensions: mbstring, pdo, pdo_sqlite, pdo_pgsql, pdo_sqlsrv, pdo_mysql
       - name: Get Composer Cache Directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"

--- a/src/Driver/HandlerInterface.php
+++ b/src/Driver/HandlerInterface.php
@@ -247,4 +247,18 @@ interface HandlerInterface
      * @throws HandlerException
      */
     public function dropConstrain(AbstractTable $table, string $constraint): void;
+
+    /**
+     * Enable foreign key constraints.
+     *
+     * Will be added in version 3.0.0.
+     */
+    // public function enableForeignKeyConstraints(): void;
+
+    /**
+     * Disable foreign key constraints.
+     *
+     * Will be added in version 3.0.0.
+     */
+    // public function disableForeignKeyConstraints(): void;
 }

--- a/src/Driver/MySQL/MySQLHandler.php
+++ b/src/Driver/MySQL/MySQLHandler.php
@@ -112,6 +112,16 @@ class MySQLHandler extends Handler
         );
     }
 
+    public function enableForeignKeyConstraints(): void
+    {
+        $this->run('SET FOREIGN_KEY_CHECKS=1;');
+    }
+
+    public function disableForeignKeyConstraints(): void
+    {
+        $this->run('SET FOREIGN_KEY_CHECKS=0;');
+    }
+
     /**
      * Get statement needed to create table.
      *

--- a/src/Driver/Postgres/PostgresHandler.php
+++ b/src/Driver/Postgres/PostgresHandler.php
@@ -126,6 +126,16 @@ class PostgresHandler extends Handler
         $this->run($query);
     }
 
+    public function enableForeignKeyConstraints(): void
+    {
+        $this->run('SET CONSTRAINTS ALL IMMEDIATE;');
+    }
+
+    public function disableForeignKeyConstraints(): void
+    {
+        $this->run('SET CONSTRAINTS ALL DEFERRED;');
+    }
+
     /**
      * @psalm-param non-empty-string $statement
      */

--- a/src/Driver/SQLServer/SQLServerHandler.php
+++ b/src/Driver/SQLServer/SQLServerHandler.php
@@ -148,6 +148,20 @@ class SQLServerHandler extends Handler
         $this->run("DROP INDEX {$this->identify($index)} ON {$this->identify($table)}");
     }
 
+    public function enableForeignKeyConstraints(): void
+    {
+        foreach ($this->getTableNames() as $table) {
+            $this->run("ALTER TABLE {$this->identify($table)} WITH CHECK CHECK CONSTRAINT ALL");
+        }
+    }
+
+    public function disableForeignKeyConstraints(): void
+    {
+        foreach ($this->getTableNames() as $table) {
+            $this->run("ALTER TABLE {$this->identify($table)} NOCHECK CONSTRAINT ALL");
+        }
+    }
+
     private function renameColumn(
         AbstractTable $table,
         AbstractColumn $initial,

--- a/src/Driver/SQLite/SQLiteHandler.php
+++ b/src/Driver/SQLite/SQLiteHandler.php
@@ -142,6 +142,16 @@ class SQLiteHandler extends Handler
         //Not supported
     }
 
+    public function enableForeignKeyConstraints(): void
+    {
+        $this->run('PRAGMA foreign_keys = ON;');
+    }
+
+    public function disableForeignKeyConstraints(): void
+    {
+        $this->run('PRAGMA foreign_keys = OFF;');
+    }
+
     /**
      * Temporary table based on parent.
      */

--- a/tests/Database/Functional/Driver/MySQL/Schema/ForeignKeysTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Schema/ForeignKeysTest.php
@@ -14,4 +14,22 @@ use Cycle\Database\Tests\Functional\Driver\Common\Schema\ForeignKeysTest as Comm
 class ForeignKeysTest extends CommonClass
 {
     public const DRIVER = 'mysql';
+
+    public function testDisableForeignKeyConstraints(): void
+    {
+        $schema = $this->schema('schema');
+        $schema->getDriver()->getSchemaHandler()->disableForeignKeyConstraints();
+        $result = $schema->getDriver()->query('SELECT @@foreign_key_checks;')->fetch();
+
+        $this->assertSame(0, $result['@@foreign_key_checks']);
+    }
+
+    public function testEnableForeignKeyConstraints(): void
+    {
+        $schema = $this->schema('schema');
+        $schema->getDriver()->getSchemaHandler()->enableForeignKeyConstraints();
+        $result = $schema->getDriver()->query('SELECT @@foreign_key_checks;')->fetch();
+
+        $this->assertSame(1, $result['@@foreign_key_checks']);
+    }
 }

--- a/tests/Database/Functional/Driver/MySQL/Schema/ForeignKeysTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Schema/ForeignKeysTest.php
@@ -18,18 +18,27 @@ class ForeignKeysTest extends CommonClass
     public function testDisableForeignKeyConstraints(): void
     {
         $schema = $this->schema('schema');
+
+        $result = $schema->getDriver()->query('SELECT @@foreign_key_checks;')->fetch();
+        $this->assertSame(1, (int) $result['@@foreign_key_checks']);
+
         $schema->getDriver()->getSchemaHandler()->disableForeignKeyConstraints();
         $result = $schema->getDriver()->query('SELECT @@foreign_key_checks;')->fetch();
 
-        $this->assertSame(0, $result['@@foreign_key_checks']);
+        $this->assertSame(0, (int) $result['@@foreign_key_checks']);
     }
 
     public function testEnableForeignKeyConstraints(): void
     {
         $schema = $this->schema('schema');
+
+        $schema->getDriver()->getSchemaHandler()->disableForeignKeyConstraints();
+        $result = $schema->getDriver()->query('SELECT @@foreign_key_checks;')->fetch();
+        $this->assertSame(0, (int) $result['@@foreign_key_checks']);
+
         $schema->getDriver()->getSchemaHandler()->enableForeignKeyConstraints();
         $result = $schema->getDriver()->query('SELECT @@foreign_key_checks;')->fetch();
 
-        $this->assertSame(1, $result['@@foreign_key_checks']);
+        $this->assertSame(1, (int) $result['@@foreign_key_checks']);
     }
 }

--- a/tests/Database/Functional/Driver/SQLite/Schema/ForeignKeysTest.php
+++ b/tests/Database/Functional/Driver/SQLite/Schema/ForeignKeysTest.php
@@ -32,4 +32,30 @@ class ForeignKeysTest extends CommonClass
         $this->assertTrue($this->schema('schema')->hasForeignKey(['external_id']));
         $this->assertFalse($this->schema('schema')->hasIndex(['external_id']));
     }
+
+    public function testDisableForeignKeyConstraints(): void
+    {
+        $schema = $this->schema('schema');
+        $schema->getDriver()->getSchemaHandler()->enableForeignKeyConstraints();
+        $result = $schema->getDriver()->query('PRAGMA foreign_keys')->fetch();
+        $this->assertSame(1, $result['foreign_keys']);
+
+        $schema->getDriver()->getSchemaHandler()->disableForeignKeyConstraints();
+        $result = $schema->getDriver()->query('PRAGMA foreign_keys')->fetch();
+
+        $this->assertSame(0, $result['foreign_keys']);
+    }
+
+    public function testEnableForeignKeyConstraints(): void
+    {
+        $schema = $this->schema('schema');
+
+        $result = $schema->getDriver()->query('PRAGMA foreign_keys')->fetch();
+        $this->assertSame(0, $result['foreign_keys']);
+
+        $schema->getDriver()->getSchemaHandler()->enableForeignKeyConstraints();
+        $result = $schema->getDriver()->query('PRAGMA foreign_keys')->fetch();
+
+        $this->assertSame(1, $result['foreign_keys']);
+    }
 }

--- a/tests/Database/Functional/Driver/SQLite/Schema/ForeignKeysTest.php
+++ b/tests/Database/Functional/Driver/SQLite/Schema/ForeignKeysTest.php
@@ -38,12 +38,12 @@ class ForeignKeysTest extends CommonClass
         $schema = $this->schema('schema');
         $schema->getDriver()->getSchemaHandler()->enableForeignKeyConstraints();
         $result = $schema->getDriver()->query('PRAGMA foreign_keys')->fetch();
-        $this->assertSame(1, $result['foreign_keys']);
+        $this->assertSame(1, (int) $result['foreign_keys']);
 
         $schema->getDriver()->getSchemaHandler()->disableForeignKeyConstraints();
         $result = $schema->getDriver()->query('PRAGMA foreign_keys')->fetch();
 
-        $this->assertSame(0, $result['foreign_keys']);
+        $this->assertSame(0, (int) $result['foreign_keys']);
     }
 
     public function testEnableForeignKeyConstraints(): void
@@ -51,11 +51,11 @@ class ForeignKeysTest extends CommonClass
         $schema = $this->schema('schema');
 
         $result = $schema->getDriver()->query('PRAGMA foreign_keys')->fetch();
-        $this->assertSame(0, $result['foreign_keys']);
+        $this->assertSame(0, (int) $result['foreign_keys']);
 
         $schema->getDriver()->getSchemaHandler()->enableForeignKeyConstraints();
         $result = $schema->getDriver()->query('PRAGMA foreign_keys')->fetch();
 
-        $this->assertSame(1, $result['foreign_keys']);
+        $this->assertSame(1, (int) $result['foreign_keys']);
     }
 }

--- a/tests/Database/Unit/Driver/Postgres/PostgresHandlerTest.php
+++ b/tests/Database/Unit/Driver/Postgres/PostgresHandlerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Unit\Driver\Postgres;
+
+use Cycle\Database\Driver\DriverInterface;
+use Cycle\Database\Driver\Postgres\PostgresHandler;
+use PHPUnit\Framework\TestCase;
+
+final class PostgresHandlerTest extends TestCase
+{
+    public function testEnableForeignKeyConstraints(): void
+    {
+        $driver = $this->createMock(DriverInterface::class);
+        $driver
+            ->expects($this->once())
+            ->method('execute')
+            ->with('SET CONSTRAINTS ALL IMMEDIATE;');
+
+        $handler = (new PostgresHandler())->withDriver($driver);
+
+        $handler->enableForeignKeyConstraints();
+    }
+
+    public function testDisableForeignKeyConstraints(): void
+    {
+        $driver = $this->createMock(DriverInterface::class);
+        $driver
+            ->expects($this->once())
+            ->method('execute')
+            ->with('SET CONSTRAINTS ALL DEFERRED;');
+
+        $handler = (new PostgresHandler())->withDriver($driver);
+
+        $handler->disableForeignKeyConstraints();
+    }
+}


### PR DESCRIPTION
### What was changed

Added `enableForeignKeyConstraints` and `disableForeignKeyConstraints` methods. These methods can be useful, for example, in testing.