### PR TITLE
Add the ability to disable cache

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -219,12 +219,9 @@ final class Database implements DatabaseInterface
         }
 
         if ($this->driver instanceof Driver) {
-            if ($database->readDriver === $database->driver) {
-                $database->readDriver = $database->readDriver->withoutCache();
-                $database->driver = $database->readDriver;
-            } else {
-                $database->driver = $database->driver->withoutCache();
-            }
+            $database->driver = $database->readDriver === $database->driver
+                ? ($database->readDriver = $database->driver->withoutCache())
+                : $database->driver->withoutCache();
 
             return $database;
         }

--- a/src/Database.php
+++ b/src/Database.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Cycle\Database;
 
+use Cycle\Database\Driver\Driver;
 use Cycle\Database\Driver\DriverInterface;
 use Cycle\Database\Query\DeleteQuery;
 use Cycle\Database\Query\InsertQuery;
@@ -207,5 +208,27 @@ final class Database implements DatabaseInterface
     public function rollback(): bool
     {
         return $this->getDriver(self::WRITE)->rollbackTransaction();
+    }
+
+    public function withoutCache(): self
+    {
+        $database = clone $this;
+
+        if ($this->readDriver instanceof Driver && $database->readDriver !== $database->driver) {
+            $database->readDriver = $database->readDriver->withoutCache();
+        }
+
+        if ($this->driver instanceof Driver) {
+            if ($database->readDriver === $database->driver) {
+                $database->readDriver = $database->readDriver->withoutCache();
+                $database->driver = $database->readDriver;
+            } else {
+                $database->driver = $database->driver->withoutCache();
+            }
+
+            return $database;
+        }
+
+        return $this;
     }
 }

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -149,4 +149,9 @@ interface DatabaseInterface
      * Rollback the active database transaction.
      */
     public function rollback(): bool;
+
+    /**
+     *  Will be added in next major release.
+     */
+    // public function withoutCache(): self;
 }

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -22,6 +22,9 @@ use Cycle\Database\Query\UpdateQuery;
  * DatabaseInterface is high level abstraction used to represent single database. You must always
  * check database type using getType() method before writing plain SQL for execute and query methods
  * (unless you are locking your module/application to one database).
+ *
+ * @method DatabaseInterface withoutCache() Get a new Database instance without query cache or the same instance
+ *         if no cache is used. Will be added the next major release.
  */
 interface DatabaseInterface
 {
@@ -96,6 +99,8 @@ interface DatabaseInterface
      * Get instance of InsertBuilder associated with current Database.
      *
      * @param string $table Table where values should be inserted to.
+     *
+     * @see self::withoutCache() May be useful to disable query cache for batch inserts.
      */
     public function insert(string $table = ''): InsertQuery;
 
@@ -149,9 +154,4 @@ interface DatabaseInterface
      * Rollback the active database transaction.
      */
     public function rollback(): bool;
-
-    /**
-     *  Will be added in next major release.
-     */
-    // public function withoutCache(): self;
 }

--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -54,6 +54,7 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
     /** @var PDOStatement[]|PDOStatementInterface[] */
     protected array $queryCache = [];
     private ?string $name = null;
+    private bool $useCache = true;
 
     protected function __construct(
         protected DriverConfig $config,
@@ -61,10 +62,12 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
         protected CompilerInterface $queryCompiler,
         BuilderInterface $queryBuilder
     ) {
+        $this->useCache = $this->config->queryCache;
+
         $this->schemaHandler = $schemaHandler->withDriver($this);
         $this->queryBuilder = $queryBuilder->withDriver($this);
 
-        if ($this->config->queryCache && $queryCompiler instanceof CachingCompilerInterface) {
+        if ($this->useCache && $queryCompiler instanceof CachingCompilerInterface) {
             $this->queryCompiler = new CompilerCache($queryCompiler);
         }
 
@@ -94,6 +97,14 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
     public function isReadonly(): bool
     {
         return $this->config->readonly;
+    }
+
+    public function withoutCache(): static
+    {
+        $driver = clone $this;
+        $driver->useCache = false;
+
+        return $driver;
     }
 
     /**
@@ -480,12 +491,12 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
      */
     protected function prepare(string $query): PDOStatement|PDOStatementInterface
     {
-        if ($this->config->queryCache && isset($this->queryCache[$query])) {
+        if ($this->useCache && isset($this->queryCache[$query])) {
             return $this->queryCache[$query];
         }
 
         $statement = $this->getPDO()->prepare($query);
-        if ($this->config->queryCache) {
+        if ($this->useCache) {
             $this->queryCache[$query] = $statement;
         }
 

--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -101,6 +101,11 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
 
     public function withoutCache(): static
     {
+        if ($this->useCache === false) {
+            // Cache already disabled
+            return $this;
+        }
+
         $driver = clone $this;
         $driver->useCache = false;
 

--- a/tests/Database/Unit/DatabaseTest.php
+++ b/tests/Database/Unit/DatabaseTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Unit;
+
+use Cycle\Database\Database;
+use Cycle\Database\Driver\Driver;
+use Cycle\Database\Driver\DriverInterface;
+use PHPUnit\Framework\TestCase;
+
+final class DatabaseTest extends TestCase
+{
+    public function testWithoutCacheWithoutReadDriver(): void
+    {
+        $driver = $this->createMock(Driver::class);
+
+        $driver
+            ->expects($this->once())
+            ->method('withoutCache');
+
+        $database = new Database('default', '', $driver);
+
+        $newDb = $database->withoutCache();
+
+        $ref = new \ReflectionProperty($newDb, 'readDriver');
+        $ref->setAccessible(true);
+
+        $this->assertNull($ref->getValue($newDb));
+        $this->assertNotSame($driver, $newDb->getDriver());
+    }
+
+    public function testWithoutCacheWithSameDriverAndReadDriver(): void
+    {
+        $driver = $this->createMock(Driver::class);
+
+        $driver
+            ->expects($this->once())
+            ->method('withoutCache');
+
+        $database = new Database('default', '', $driver, $driver);
+
+        $newDb = $database->withoutCache();
+
+        $refDriver = new \ReflectionProperty($newDb, 'driver');
+        $refDriver->setAccessible(true);
+
+        $refReadDriver = new \ReflectionProperty($newDb, 'readDriver');
+        $refReadDriver->setAccessible(true);
+
+        $this->assertSame($refDriver->getValue($newDb), $refReadDriver->getValue($newDb));
+    }
+
+    public function testWithoutCacheWithDriverAndReadDriver(): void
+    {
+        $driver = $this->createMock(Driver::class);
+        $readDriver = $this->createMock(Driver::class);
+
+        $driver
+            ->expects($this->once())
+            ->method('withoutCache');
+
+        $readDriver
+            ->expects($this->once())
+            ->method('withoutCache');
+
+        $database = new Database('default', '', $driver, $readDriver);
+
+        $newDb = $database->withoutCache();
+
+        $refDriver = new \ReflectionProperty($newDb, 'driver');
+        $refDriver->setAccessible(true);
+
+        $refReadDriver = new \ReflectionProperty($newDb, 'readDriver');
+        $refReadDriver->setAccessible(true);
+
+        $this->assertNotSame($refDriver->getValue($newDb), $refReadDriver->getValue($newDb));
+        $this->assertNotSame($driver, $refDriver->getValue($newDb));
+        $this->assertNotSame($readDriver, $refReadDriver->getValue($newDb));
+    }
+
+    public function testWithoutCacheWithoutReadDriverAndWithoutMethod(): void
+    {
+        $driver = $this->createMock(DriverInterface::class);
+
+        $database = new Database('default', '', $driver);
+
+        $newDb = $database->withoutCache();
+
+        $ref = new \ReflectionProperty($newDb, 'readDriver');
+        $ref->setAccessible(true);
+
+        $this->assertNull($ref->getValue($newDb));
+        $this->assertSame($driver, $newDb->getDriver());
+    }
+
+    public function testWithoutCacheWithDriverAndReadDriverWithoutMethod(): void
+    {
+        $driver = $this->createMock(DriverInterface::class);
+        $readDriver = $this->createMock(DriverInterface::class);
+
+        $database = new Database('default', '', $driver, $readDriver);
+
+        $newDb = $database->withoutCache();
+
+        $refDriver = new \ReflectionProperty($newDb, 'driver');
+        $refDriver->setAccessible(true);
+
+        $refReadDriver = new \ReflectionProperty($newDb, 'readDriver');
+        $refReadDriver->setAccessible(true);
+
+        $this->assertNotSame($refDriver->getValue($newDb), $refReadDriver->getValue($newDb));
+        $this->assertSame($driver, $refDriver->getValue($newDb));
+        $this->assertSame($readDriver, $refReadDriver->getValue($newDb));
+    }
+
+    public function testWithoutCacheWithSameDriversAndWithoutMethod(): void
+    {
+        $driver = $this->createMock(DriverInterface::class);
+
+        $database = new Database('default', '', $driver, $driver);
+
+        $newDb = $database->withoutCache();
+
+        $refDriver = new \ReflectionProperty($newDb, 'driver');
+        $refDriver->setAccessible(true);
+
+        $refReadDriver = new \ReflectionProperty($newDb, 'readDriver');
+        $refReadDriver->setAccessible(true);
+
+        $this->assertSame($refDriver->getValue($newDb), $refReadDriver->getValue($newDb));
+        $this->assertSame($driver, $refDriver->getValue($newDb));
+        $this->assertSame($driver, $refReadDriver->getValue($newDb));
+    }
+}

--- a/tests/Database/Unit/Driver/AbstractDriverTest.php
+++ b/tests/Database/Unit/Driver/AbstractDriverTest.php
@@ -167,6 +167,22 @@ class AbstractDriverTest extends TestCase
         $this->assertFalse($ref->getValue($driver->withoutCache()));
     }
 
+    public function testWithoutCacheTwice(): void
+    {
+        $driver = TestDriver::create(new SQLiteDriverConfig(queryCache: true));
+
+        $ncDriver = $driver->withoutCache();
+
+        $this->assertSame($ncDriver, $ncDriver->withoutCache());
+    }
+
+    public function testWithoutCacheOnWithoutCacheInitially(): void
+    {
+        $driver = TestDriver::create(new SQLiteDriverConfig(queryCache: false));
+
+        $this->assertSame($driver, $driver->withoutCache());
+    }
+
     public function testPdoNotClonedAfterCacheDisabled(): void
     {
         $ref = new \ReflectionMethod(Driver::class, 'getPDO');


### PR DESCRIPTION
The ability to disable caching has been introduced by using the `Cycle\Database\Database` class or driver classes that inherit from `Cycle\Database\Driver\Driver`. This can be beneficial in certain scenarios, such as when inserting large volumes of data with varying numbers of elements in each query. In such a situation, each query differs from the previous one and caches.

Part of #136