### PR TITLE
Add the ability to set JSON default value as an array

### DIFF
--- a/src/Driver/Postgres/Schema/PostgresColumn.php
+++ b/src/Driver/Postgres/Schema/PostgresColumn.php
@@ -607,6 +607,11 @@ class PostgresColumn extends AbstractColumn
         return '(' . $this->size . ')';
     }
 
+    protected static function isJson(AbstractColumn $column): bool
+    {
+        return $column->getAbstractType() === 'json' || $column->getAbstractType() === 'jsonb';
+    }
+
     /**
      * Get/generate name for enum constraint.
      */

--- a/src/Driver/SQLServer/Schema/SQLServerColumn.php
+++ b/src/Driver/SQLServer/Schema/SQLServerColumn.php
@@ -338,6 +338,17 @@ class SQLServerColumn extends AbstractColumn
         return $column;
     }
 
+    public function defaultValue(mixed $value): self
+    {
+        if (\is_array($value) && $this->getAbstractType() === 'text') {
+            $this->defaultValue = \json_encode($value, \JSON_THROW_ON_ERROR);
+
+            return $this;
+        }
+
+        return parent::defaultValue($value);
+    }
+
     /**
      * @psalm-return non-empty-string
      */

--- a/src/Driver/SQLServer/Schema/SQLServerColumn.php
+++ b/src/Driver/SQLServer/Schema/SQLServerColumn.php
@@ -375,11 +375,9 @@ class SQLServerColumn extends AbstractColumn
         return $this->defaultConstraint;
     }
 
-    /**
-     * In SQL Server, we cannot determine if a column has a JSON type.
-     */
     protected static function isJson(AbstractColumn $column): ?bool
     {
+        // In SQL Server, we cannot determine if a column has a JSON type.
         return $column->getAbstractType() === 'text' ? null : false;
     }
 

--- a/src/Driver/SQLServer/Schema/SQLServerColumn.php
+++ b/src/Driver/SQLServer/Schema/SQLServerColumn.php
@@ -387,6 +387,14 @@ class SQLServerColumn extends AbstractColumn
     }
 
     /**
+     * In SQL Server, we cannot determine if a column has a JSON type.
+     */
+    protected static function isJson(AbstractColumn $column): ?bool
+    {
+        return null;
+    }
+
+    /**
      * In SQLServer we can emulate enums similar way as in Postgres via column constrain.
      *
      * @psalm-return non-empty-string

--- a/src/Driver/SQLServer/Schema/SQLServerColumn.php
+++ b/src/Driver/SQLServer/Schema/SQLServerColumn.php
@@ -338,17 +338,6 @@ class SQLServerColumn extends AbstractColumn
         return $column;
     }
 
-    public function defaultValue(mixed $value): self
-    {
-        if (\is_array($value) && $this->getAbstractType() === 'text') {
-            $this->defaultValue = \json_encode($value, \JSON_THROW_ON_ERROR);
-
-            return $this;
-        }
-
-        return parent::defaultValue($value);
-    }
-
     /**
      * @psalm-return non-empty-string
      */
@@ -391,7 +380,7 @@ class SQLServerColumn extends AbstractColumn
      */
     protected static function isJson(AbstractColumn $column): ?bool
     {
-        return null;
+        return $column->getAbstractType() === 'text' ? null : false;
     }
 
     /**

--- a/src/Driver/SQLite/Schema/SQLiteColumn.php
+++ b/src/Driver/SQLite/Schema/SQLiteColumn.php
@@ -236,6 +236,17 @@ class SQLiteColumn extends AbstractColumn
         return $column;
     }
 
+    public function defaultValue(mixed $value): self
+    {
+        if (\is_array($value) && $this->getAbstractType() === 'text') {
+            $this->defaultValue = \json_encode($value, \JSON_THROW_ON_ERROR);
+
+            return $this;
+        }
+
+        return parent::defaultValue($value);
+    }
+
     protected function quoteEnum(DriverInterface $driver): string
     {
         return '';

--- a/src/Driver/SQLite/Schema/SQLiteColumn.php
+++ b/src/Driver/SQLite/Schema/SQLiteColumn.php
@@ -256,4 +256,12 @@ class SQLiteColumn extends AbstractColumn
     {
         return false;
     }
+
+    /**
+     * In SQLite, we cannot determine if a column has a JSON type.
+     */
+    protected static function isJson(AbstractColumn $column): ?bool
+    {
+        return null;
+    }
 }

--- a/src/Driver/SQLite/Schema/SQLiteColumn.php
+++ b/src/Driver/SQLite/Schema/SQLiteColumn.php
@@ -246,11 +246,9 @@ class SQLiteColumn extends AbstractColumn
         return false;
     }
 
-    /**
-     * In SQLite, we cannot determine if a column has a JSON type.
-     */
     protected static function isJson(AbstractColumn $column): ?bool
     {
+        // In SQLite, we cannot determine if a column has a JSON type.
         return $column->getAbstractType() === 'text' ? null : false;
     }
 }

--- a/src/Driver/SQLite/Schema/SQLiteColumn.php
+++ b/src/Driver/SQLite/Schema/SQLiteColumn.php
@@ -236,17 +236,6 @@ class SQLiteColumn extends AbstractColumn
         return $column;
     }
 
-    public function defaultValue(mixed $value): self
-    {
-        if (\is_array($value) && $this->getAbstractType() === 'text') {
-            $this->defaultValue = \json_encode($value, \JSON_THROW_ON_ERROR);
-
-            return $this;
-        }
-
-        return parent::defaultValue($value);
-    }
-
     protected function quoteEnum(DriverInterface $driver): string
     {
         return '';
@@ -262,6 +251,6 @@ class SQLiteColumn extends AbstractColumn
      */
     protected static function isJson(AbstractColumn $column): ?bool
     {
-        return null;
+        return $column->getAbstractType() === 'text' ? null : false;
     }
 }

--- a/src/Schema/AbstractColumn.php
+++ b/src/Schema/AbstractColumn.php
@@ -527,7 +527,10 @@ abstract class AbstractColumn implements ColumnInterface, ElementInterface
     {
         $this->defaultValue = match (true) {
             $value === self::DATETIME_NOW => static::DATETIME_NOW,
-            static::isJson($this) === true && \is_array($value) => \json_encode($value, \JSON_THROW_ON_ERROR),
+            static::isJson($this) !== false && \is_array($value) => \json_encode(
+                $value,
+                \JSON_UNESCAPED_UNICODE|\JSON_THROW_ON_ERROR,
+            ),
             default => $value
         };
 

--- a/src/Schema/AbstractColumn.php
+++ b/src/Schema/AbstractColumn.php
@@ -527,7 +527,7 @@ abstract class AbstractColumn implements ColumnInterface, ElementInterface
     {
         $this->defaultValue = match (true) {
             $value === self::DATETIME_NOW => static::DATETIME_NOW,
-            static::isJson($this) && \is_array($value) => \json_encode($value, \JSON_THROW_ON_ERROR),
+            static::isJson($this) === true && \is_array($value) => \json_encode($value, \JSON_THROW_ON_ERROR),
             default => $value
         };
 
@@ -766,7 +766,12 @@ abstract class AbstractColumn implements ColumnInterface, ElementInterface
         return $column->getAbstractType() === 'enum';
     }
 
-    protected static function isJson(self $column): bool
+    /**
+     * Checks if the column is JSON or no.
+     *
+     * Returns null if it's impossible to explicitly define the JSON type.
+     */
+    protected static function isJson(self $column): ?bool
     {
         return $column->getAbstractType() === 'json';
     }

--- a/src/Schema/AbstractColumn.php
+++ b/src/Schema/AbstractColumn.php
@@ -525,12 +525,11 @@ abstract class AbstractColumn implements ColumnInterface, ElementInterface
      */
     public function defaultValue(mixed $value): self
     {
-        //Forcing driver specific values
-        if ($value === self::DATETIME_NOW) {
-            $value = static::DATETIME_NOW;
-        }
-
-        $this->defaultValue = $value;
+        $this->defaultValue = match (true) {
+            $value === self::DATETIME_NOW => static::DATETIME_NOW,
+            static::isJson($this) && \is_array($value) => \json_encode($value, \JSON_THROW_ON_ERROR),
+            default => $value
+        };
 
         return $this;
     }
@@ -765,5 +764,10 @@ abstract class AbstractColumn implements ColumnInterface, ElementInterface
     protected static function isEnum(self $column): bool
     {
         return $column->getAbstractType() === 'enum';
+    }
+
+    protected static function isJson(self $column): bool
+    {
+        return $column->getAbstractType() === 'json';
     }
 }

--- a/tests/Database/Functional/Driver/Common/Schema/DefaultValueTest.php
+++ b/tests/Database/Functional/Driver/Common/Schema/DefaultValueTest.php
@@ -344,6 +344,19 @@ abstract class DefaultValueTest extends BaseTest
         $this->assertTrue($schema->column('target')->compare($column));
     }
 
+    public function testJsonDefaultValueArray(): void
+    {
+        $schema = $this->schema('table');
+        $this->assertFalse($schema->exists());
+
+        $column = $schema->json('target')->defaultValue(['foo' => 'bar', 'baz' => 100.0]);
+
+        $schema->save();
+        $schema = $this->schema('table');
+        $this->assertTrue($schema->exists());
+        $this->assertTrue($schema->column('target')->compare($column));
+    }
+
     public function testEnumDefaultValueNull(): void
     {
         $schema = $this->schema('table');

--- a/tests/Database/Functional/Driver/MySQL/Schema/DefaultValueTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Schema/DefaultValueTest.php
@@ -36,6 +36,13 @@ class DefaultValueTest extends CommonClass
         parent::testJsonDefaultValueString();
     }
 
+    public function testJsonDefaultValueArray(): void
+    {
+        $this->expectException(\Cycle\Database\Driver\MySQL\Exception\MySQLException::class);
+        $this->expectExceptionMessage('Column table.target of type text/blob/json can not have non empty default value');
+        parent::testJsonDefaultValueArray();
+    }
+
     public function testJsonDefaultValueEmpty(): void
     {
         $this->expectException(\Cycle\Database\Driver\MySQL\Exception\MySQLException::class);


### PR DESCRIPTION
Added the ability to use an array as a default value in JSON columns.

### AbstractColumn

```php
$column = $schema->json('settings')->defaultValue(['theme' => 'dark']);
```

### Migrations (with cycle/migrations package) 

```php
public function up(): void
{
    $this->table('users')
        ->addColumn('settings', 'json', ['nullable' => false, 'default' => ['theme' => 'dark']])
        ->create();
}
```

### Attributes (with cycle/orm and cycle/annotated packages) 

```php
use Cycle\Annotated\Annotation\Column;
use Cycle\Annotated\Annotation\Entity;

#[Entity]
class User
{
    // ...
    
    #[Column(type: 'json', default: ['theme' => 'dark'])]
    private array $settings;
    
    // ...
}
```

Closes: #54 