### PR TITLE
Fixing `whereJsonContains` and `whereJsonDoesntContain` methods with a single column name

### DIFF
--- a/src/Driver/Postgres/Injection/CompileJsonContains.php
+++ b/src/Driver/Postgres/Injection/CompileJsonContains.php
@@ -17,7 +17,11 @@ class CompileJsonContains extends PostgresJsonExpression
     {
         $path = $this->getPath($statement);
         $field = $this->getField($statement);
-        $attribute = $this->getAttribute($statement);
+        $attribute = $this->findAttribute($statement);
+
+        if (empty($attribute)) {
+            return \sprintf('(%s)::jsonb @> ?', $field);
+        }
 
         if (!empty($path)) {
             return \sprintf('(%s->%s->%s)::jsonb @> ?', $field, $path, $attribute);

--- a/src/Driver/Postgres/Injection/PostgresJsonExpression.php
+++ b/src/Driver/Postgres/Injection/PostgresJsonExpression.php
@@ -41,9 +41,26 @@ abstract class PostgresJsonExpression extends JsonExpression
      */
     protected function getAttribute(string $statement): string|int
     {
+        $attribute = $this->findAttribute($statement);
+        if ($attribute === null) {
+            throw new DriverException('Invalid statement. Unable to extract attribute.');
+        }
+
+        return $attribute;
+    }
+
+    /**
+     * Returns the attribute (last part of the full path). Returns null if the attribute is not found.
+     *
+     * @param non-empty-string $statement
+     *
+     * @return int|non-empty-string|null
+     */
+    protected function findAttribute(string $statement): string|int|null
+    {
         $path = $this->getPathArray($statement);
         if ($path === []) {
-            throw new DriverException('Invalid statement. Unable to extract attribute.');
+            return null;
         }
 
         $attribute = \array_pop($path);

--- a/tests/Database/Functional/Driver/MySQL/Query/DeleteQueryTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Query/DeleteQueryTest.php
@@ -129,7 +129,7 @@ class DeleteQueryTest extends CommonClass
             ->delete('table')
             ->whereJsonContains('settings', []);
 
-        $this->assertSameQuery("DELETE FROM {table} WHERE json_contains({settings}, ?)", $select);
+        $this->assertSameQuery('DELETE FROM {table} WHERE json_contains({settings}, ?)', $select);
         $this->assertSameParameters([json_encode([])], $select);
     }
 
@@ -206,7 +206,7 @@ class DeleteQueryTest extends CommonClass
             ->delete('table')
             ->whereJsonDoesntContain('settings', []);
 
-        $this->assertSameQuery("DELETE FROM {table} WHERE NOT json_contains({settings}, ?)", $select);
+        $this->assertSameQuery('DELETE FROM {table} WHERE NOT json_contains({settings}, ?)', $select);
         $this->assertSameParameters([json_encode([])], $select);
     }
 

--- a/tests/Database/Functional/Driver/MySQL/Query/DeleteQueryTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Query/DeleteQueryTest.php
@@ -123,6 +123,16 @@ class DeleteQueryTest extends CommonClass
         $this->assertSameParameters([json_encode('+1234567890')], $select);
     }
 
+    public function testDeleteWithWhereJsonContainsSinglePath(): void
+    {
+        $select = $this->database
+            ->delete('table')
+            ->whereJsonContains('settings', []);
+
+        $this->assertSameQuery("DELETE FROM {table} WHERE json_contains({settings}, ?)", $select);
+        $this->assertSameParameters([json_encode([])], $select);
+    }
+
     public function testDeleteWithWhereJsonContainsArray(): void
     {
         $select = $this->database
@@ -188,6 +198,16 @@ class DeleteQueryTest extends CommonClass
             $select
         );
         $this->assertSameParameters([json_encode('+1234567890')], $select);
+    }
+
+    public function testDeleteWithWhereJsonDoesntContainSinglePath(): void
+    {
+        $select = $this->database
+            ->delete('table')
+            ->whereJsonDoesntContain('settings', []);
+
+        $this->assertSameQuery("DELETE FROM {table} WHERE NOT json_contains({settings}, ?)", $select);
+        $this->assertSameParameters([json_encode([])], $select);
     }
 
     public function testDeleteWithWhereJsonDoesntContainArray(): void

--- a/tests/Database/Functional/Driver/MySQL/Query/SelectQueryTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Query/SelectQueryTest.php
@@ -148,7 +148,7 @@ class SelectQueryTest extends CommonClass
             ->from('table')
             ->whereJsonContains('settings', []);
 
-        $this->assertSameQuery("SELECT * FROM {table} WHERE json_contains({settings}, ?)", $select);
+        $this->assertSameQuery('SELECT * FROM {table} WHERE json_contains({settings}, ?)', $select);
         $this->assertSameParameters([json_encode([])], $select);
     }
 
@@ -230,7 +230,7 @@ class SelectQueryTest extends CommonClass
             ->from('table')
             ->whereJsonDoesntContain('settings', []);
 
-        $this->assertSameQuery("SELECT * FROM {table} WHERE NOT json_contains({settings}, ?)", $select);
+        $this->assertSameQuery('SELECT * FROM {table} WHERE NOT json_contains({settings}, ?)', $select);
         $this->assertSameParameters([json_encode([])], $select);
     }
 

--- a/tests/Database/Functional/Driver/MySQL/Query/SelectQueryTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Query/SelectQueryTest.php
@@ -141,6 +141,17 @@ class SelectQueryTest extends CommonClass
         $this->assertSameParameters([json_encode('+1234567890')], $select);
     }
 
+    public function testSelectWithWhereJsonContainsSinglePath(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from('table')
+            ->whereJsonContains('settings', []);
+
+        $this->assertSameQuery("SELECT * FROM {table} WHERE json_contains({settings}, ?)", $select);
+        $this->assertSameParameters([json_encode([])], $select);
+    }
+
     public function testSelectWithWhereJsonContainsArray(): void
     {
         $select = $this->database
@@ -210,6 +221,17 @@ class SelectQueryTest extends CommonClass
             $select
         );
         $this->assertSameParameters([json_encode('+1234567890')], $select);
+    }
+
+    public function testSelectWithWhereJsonDoesntContainSinglePath(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from('table')
+            ->whereJsonDoesntContain('settings', []);
+
+        $this->assertSameQuery("SELECT * FROM {table} WHERE NOT json_contains({settings}, ?)", $select);
+        $this->assertSameParameters([json_encode([])], $select);
     }
 
     public function testSelectWithWhereJsonDoesntContainArray(): void

--- a/tests/Database/Functional/Driver/MySQL/Query/UpdateQueryTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Query/UpdateQueryTest.php
@@ -129,6 +129,17 @@ class UpdateQueryTest extends CommonClass
         $this->assertSameParameters(['value', json_encode('+1234567890')], $select);
     }
 
+    public function testUpdateWithWhereJsonContainsSinglePath(): void
+    {
+        $select = $this->database
+            ->update('table')
+            ->values(['some' => 'value'])
+            ->whereJsonContains('settings', []);
+
+        $this->assertSameQuery("UPDATE {table} SET {some} = ? WHERE json_contains({settings}, ?)", $select);
+        $this->assertSameParameters(['value', json_encode([])], $select);
+    }
+
     public function testUpdateWithWhereJsonContainsArray(): void
     {
         $select = $this->database
@@ -198,6 +209,17 @@ class UpdateQueryTest extends CommonClass
             $select
         );
         $this->assertSameParameters(['value', json_encode('+1234567890')], $select);
+    }
+
+    public function testUpdateWithWhereJsonDoesntContainSinglePath(): void
+    {
+        $select = $this->database
+            ->update('table')
+            ->values(['some' => 'value'])
+            ->whereJsonDoesntContain('settings', []);
+
+        $this->assertSameQuery("UPDATE {table} SET {some} = ? WHERE NOT json_contains({settings}, ?)", $select);
+        $this->assertSameParameters(['value', json_encode([])], $select);
     }
 
     public function testUpdateWithWhereJsonDoesntContainArray(): void

--- a/tests/Database/Functional/Driver/MySQL/Query/UpdateQueryTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Query/UpdateQueryTest.php
@@ -136,7 +136,7 @@ class UpdateQueryTest extends CommonClass
             ->values(['some' => 'value'])
             ->whereJsonContains('settings', []);
 
-        $this->assertSameQuery("UPDATE {table} SET {some} = ? WHERE json_contains({settings}, ?)", $select);
+        $this->assertSameQuery('UPDATE {table} SET {some} = ? WHERE json_contains({settings}, ?)', $select);
         $this->assertSameParameters(['value', json_encode([])], $select);
     }
 
@@ -218,7 +218,7 @@ class UpdateQueryTest extends CommonClass
             ->values(['some' => 'value'])
             ->whereJsonDoesntContain('settings', []);
 
-        $this->assertSameQuery("UPDATE {table} SET {some} = ? WHERE NOT json_contains({settings}, ?)", $select);
+        $this->assertSameQuery('UPDATE {table} SET {some} = ? WHERE NOT json_contains({settings}, ?)', $select);
         $this->assertSameParameters(['value', json_encode([])], $select);
     }
 

--- a/tests/Database/Functional/Driver/Postgres/Query/DeleteQueryTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Query/DeleteQueryTest.php
@@ -111,6 +111,16 @@ class DeleteQueryTest extends CommonClass
         $this->assertSameParameters([json_encode('+1234567890')], $select);
     }
 
+    public function testDeleteWithWhereJsonContainsSinglePath(): void
+    {
+        $select = $this->database
+            ->delete('table')
+            ->whereJsonContains('settings', []);
+
+        $this->assertSameQuery("DELETE FROM {table} WHERE ({settings})::jsonb @> ?", $select);
+        $this->assertSameParameters([json_encode([])], $select);
+    }
+
     public function testDeleteWithWhereJsonContainsArray(): void
     {
         $select = $this->database
@@ -176,6 +186,16 @@ class DeleteQueryTest extends CommonClass
             $select
         );
         $this->assertSameParameters([json_encode('+1234567890')], $select);
+    }
+
+    public function testDeleteWithWhereJsonDoesntContainSinglePath(): void
+    {
+        $select = $this->database
+            ->delete('table')
+            ->whereJsonDoesntContain('settings', []);
+
+        $this->assertSameQuery("DELETE FROM {table} WHERE NOT ({settings})::jsonb @> ?", $select);
+        $this->assertSameParameters([json_encode([])], $select);
     }
 
     public function testDeleteWithWhereJsonDoesntContainArray(): void

--- a/tests/Database/Functional/Driver/Postgres/Query/DeleteQueryTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Query/DeleteQueryTest.php
@@ -117,7 +117,7 @@ class DeleteQueryTest extends CommonClass
             ->delete('table')
             ->whereJsonContains('settings', []);
 
-        $this->assertSameQuery("DELETE FROM {table} WHERE ({settings})::jsonb @> ?", $select);
+        $this->assertSameQuery('DELETE FROM {table} WHERE ({settings})::jsonb @> ?', $select);
         $this->assertSameParameters([json_encode([])], $select);
     }
 
@@ -194,7 +194,7 @@ class DeleteQueryTest extends CommonClass
             ->delete('table')
             ->whereJsonDoesntContain('settings', []);
 
-        $this->assertSameQuery("DELETE FROM {table} WHERE NOT ({settings})::jsonb @> ?", $select);
+        $this->assertSameQuery('DELETE FROM {table} WHERE NOT ({settings})::jsonb @> ?', $select);
         $this->assertSameParameters([json_encode([])], $select);
     }
 

--- a/tests/Database/Functional/Driver/Postgres/Query/SelectQueryTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Query/SelectQueryTest.php
@@ -121,7 +121,7 @@ class SelectQueryTest extends CommonClass
             ->from('table')
             ->whereJsonContains('settings', []);
 
-        $this->assertSameQuery("SELECT * FROM {table} WHERE ({settings})::jsonb @> ?", $select);
+        $this->assertSameQuery('SELECT * FROM {table} WHERE ({settings})::jsonb @> ?', $select);
         $this->assertSameParameters([json_encode([])], $select);
     }
 
@@ -203,7 +203,7 @@ class SelectQueryTest extends CommonClass
             ->from('table')
             ->whereJsonDoesntContain('settings', []);
 
-        $this->assertSameQuery("SELECT * FROM {table} WHERE NOT ({settings})::jsonb @> ?", $select);
+        $this->assertSameQuery('SELECT * FROM {table} WHERE NOT ({settings})::jsonb @> ?', $select);
         $this->assertSameParameters([json_encode('+1234567890')], $select);
     }
 

--- a/tests/Database/Functional/Driver/Postgres/Query/SelectQueryTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Query/SelectQueryTest.php
@@ -114,6 +114,17 @@ class SelectQueryTest extends CommonClass
         $this->assertSameParameters([json_encode('+1234567890')], $select);
     }
 
+    public function testSelectWithWhereJsonContainsSinglePath(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from('table')
+            ->whereJsonContains('settings', []);
+
+        $this->assertSameQuery("SELECT * FROM {table} WHERE ({settings})::jsonb @> ?", $select);
+        $this->assertSameParameters([json_encode([])], $select);
+    }
+
     public function testSelectWithWhereJsonContainsArray(): void
     {
         $select = $this->database
@@ -182,6 +193,17 @@ class SelectQueryTest extends CommonClass
             "SELECT * FROM {table} WHERE NOT ({settings}->'phones'->'work')::jsonb @> ?",
             $select
         );
+        $this->assertSameParameters([json_encode('+1234567890')], $select);
+    }
+
+    public function testSelectWithWhereJsonDoesntContainSinglePath(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from('table')
+            ->whereJsonDoesntContain('settings', []);
+
+        $this->assertSameQuery("SELECT * FROM {table} WHERE NOT ({settings})::jsonb @> ?", $select);
         $this->assertSameParameters([json_encode('+1234567890')], $select);
     }
 

--- a/tests/Database/Functional/Driver/Postgres/Query/SelectQueryTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Query/SelectQueryTest.php
@@ -204,7 +204,7 @@ class SelectQueryTest extends CommonClass
             ->whereJsonDoesntContain('settings', []);
 
         $this->assertSameQuery('SELECT * FROM {table} WHERE NOT ({settings})::jsonb @> ?', $select);
-        $this->assertSameParameters([json_encode('+1234567890')], $select);
+        $this->assertSameParameters([json_encode([])], $select);
     }
 
     public function testSelectWithWhereJsonDoesntContainArray(): void

--- a/tests/Database/Functional/Driver/Postgres/Query/UpdateQueryTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Query/UpdateQueryTest.php
@@ -116,10 +116,21 @@ class UpdateQueryTest extends CommonClass
             ->whereJsonContains('settings->phones->work', '+1234567890');
 
         $this->assertSameQuery(
-            "UPDATE {table} SET {some} = ? WHERE({settings}->'phones'->'work')::jsonb @> ?",
+            "UPDATE {table} SET {some} = ? WHERE ({settings}->'phones'->'work')::jsonb @> ?",
             $select
         );
         $this->assertSameParameters(['value', json_encode('+1234567890')], $select);
+    }
+
+    public function testUpdateWithWhereJsonContainsSinglePath(): void
+    {
+        $select = $this->database
+            ->update('table')
+            ->values(['some' => 'value'])
+            ->whereJsonContains('settings', []);
+
+        $this->assertSameQuery("UPDATE {table} SET {some} = ? WHERE ({settings})::jsonb @> ?", $select);
+        $this->assertSameParameters(['value', json_encode([])], $select);
     }
 
     public function testUpdateWithWhereJsonContainsArray(): void
@@ -192,6 +203,17 @@ class UpdateQueryTest extends CommonClass
             $select
         );
         $this->assertSameParameters(['value', json_encode('+1234567890')], $select);
+    }
+
+    public function testUpdateWithWhereJsonDoesntContainSinglePath(): void
+    {
+        $select = $this->database
+            ->update('table')
+            ->values(['some' => 'value'])
+            ->whereJsonDoesntContain('settings', []);
+
+        $this->assertSameQuery("UPDATE {table} SET {some} = ? WHERE NOT ({settings})::jsonb @> ?", $select);
+        $this->assertSameParameters(['value', json_encode([])], $select);
     }
 
     public function testUpdateWithWhereJsonDoesntContainArray(): void

--- a/tests/Database/Functional/Driver/Postgres/Query/UpdateQueryTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Query/UpdateQueryTest.php
@@ -129,7 +129,7 @@ class UpdateQueryTest extends CommonClass
             ->values(['some' => 'value'])
             ->whereJsonContains('settings', []);
 
-        $this->assertSameQuery("UPDATE {table} SET {some} = ? WHERE ({settings})::jsonb @> ?", $select);
+        $this->assertSameQuery('UPDATE {table} SET {some} = ? WHERE ({settings})::jsonb @> ?', $select);
         $this->assertSameParameters(['value', json_encode([])], $select);
     }
 
@@ -212,7 +212,7 @@ class UpdateQueryTest extends CommonClass
             ->values(['some' => 'value'])
             ->whereJsonDoesntContain('settings', []);
 
-        $this->assertSameQuery("UPDATE {table} SET {some} = ? WHERE NOT ({settings})::jsonb @> ?", $select);
+        $this->assertSameQuery('UPDATE {table} SET {some} = ? WHERE NOT ({settings})::jsonb @> ?', $select);
         $this->assertSameParameters(['value', json_encode([])], $select);
     }
 

--- a/tests/Database/Unit/Driver/JsonerTest.php
+++ b/tests/Database/Unit/Driver/JsonerTest.php
@@ -60,7 +60,7 @@ final class JsonerTest extends TestCase
         // JsonSerializable object will be converted to JSON string correctly if 'encode' is set to 'true'
         yield [
             new class () implements \JsonSerializable {
-                public function jsonSerialize()
+                public function jsonSerialize(): array
                 {
                     return ['foo' => 'bar'];
                 }


### PR DESCRIPTION
- [x] Write tests to reproduce the issue
- [x] Make a bugfix

### Bug

When calling the `whereJsonContains` and `whereJsonDoesntContain` methods and passing only the column name to PostgreSQL:

```php
$data = $database->select()
    ->from('users')
    ->whereJsonDoesntContain('permissions', [])
    ->fetchAll();
```
 We get the error **Cycle\Database\Exception\DriverException : Invalid statement. Unable to extract attribute.** instead of getting results.