### PR TITLE
Add `varbinary` support in MySQL

### DIFF
--- a/src/Driver/MySQL/Schema/MySQLColumn.php
+++ b/src/Driver/MySQL/Schema/MySQLColumn.php
@@ -315,7 +315,7 @@ class MySQLColumn extends AbstractColumn
     }
 
     /**
-     * @param 0|positive-int $size
+     * @param int<0, max> $size
      */
     public function varbinary(int $size = 255): self
     {
@@ -329,7 +329,7 @@ class MySQLColumn extends AbstractColumn
     }
 
     /**
-     * @param 0|positive-int $size
+     * @param int<0, max> $size
      */
     public function binary(int $size = 0): self
     {

--- a/src/Driver/MySQL/Schema/MySQLColumn.php
+++ b/src/Driver/MySQL/Schema/MySQLColumn.php
@@ -153,7 +153,9 @@ class MySQLColumn extends AbstractColumn
         'json',
     ];
 
-    #[ColumnAttribute(['int', 'tinyint', 'smallint', 'bigint', 'varchar', 'varbinary'])]
+    #[ColumnAttribute(
+        ['int', 'tinyint', 'smallint', 'bigint', 'varchar', 'varbinary', 'time', 'datetime', 'timestamp']
+    )]
     protected int $size = 0;
 
     /**

--- a/src/Driver/MySQL/Schema/MySQLColumn.php
+++ b/src/Driver/MySQL/Schema/MySQLColumn.php
@@ -40,6 +40,8 @@ class MySQLColumn extends AbstractColumn
      */
     public const DATETIME_NOW = 'CURRENT_TIMESTAMP';
 
+    public const EXCLUDE_FROM_COMPARE = ['size', 'timezone', 'userType', 'attributes'];
+
     protected const INTEGER_TYPES = ['tinyint', 'smallint', 'mediumint', 'int', 'bigint'];
 
     protected array $mapping = [
@@ -151,7 +153,7 @@ class MySQLColumn extends AbstractColumn
         'json',
     ];
 
-    #[ColumnAttribute(['string', 'varbinary'])]
+    #[ColumnAttribute(['int', 'tinyint', 'smallint', 'bigint', 'varchar', 'varbinary'])]
     protected int $size = 0;
 
     /**
@@ -292,8 +294,13 @@ class MySQLColumn extends AbstractColumn
 
     public function compare(AbstractColumn $initial): bool
     {
-        assert($initial instanceof self);
-        return ! (!parent::compare($initial));
+        $result = parent::compare($initial);
+
+        if ($this->type === 'varchar' || $this->type === 'varbinary') {
+            return $result && $this->size === $initial->size;
+        }
+
+        return $result;
     }
 
     public function isUnsigned(): bool

--- a/src/Driver/MySQL/Schema/MySQLColumn.php
+++ b/src/Driver/MySQL/Schema/MySQLColumn.php
@@ -329,6 +329,9 @@ class MySQLColumn extends AbstractColumn
     }
 
     /**
+     * If a size is provided, a varbinary column of the specified size will be created.
+     * Otherwise, a blob type column will be created.
+     *
      * @param int<0, max> $size
      */
     public function binary(int $size = 0): self

--- a/src/Driver/MySQL/Schema/MySQLColumn.php
+++ b/src/Driver/MySQL/Schema/MySQLColumn.php
@@ -315,7 +315,7 @@ class MySQLColumn extends AbstractColumn
     }
 
     /**
-     * @param positive-int|0 $size
+     * @param 0|positive-int $size
      */
     public function varbinary(int $size = 255): self
     {
@@ -329,7 +329,7 @@ class MySQLColumn extends AbstractColumn
     }
 
     /**
-     * @param positive-int|0 $size
+     * @param 0|positive-int $size
      */
     public function binary(int $size = 0): self
     {

--- a/src/Driver/MySQL/Schema/MySQLColumn.php
+++ b/src/Driver/MySQL/Schema/MySQLColumn.php
@@ -13,6 +13,7 @@ namespace Cycle\Database\Driver\MySQL\Schema;
 
 use Cycle\Database\Driver\DriverInterface;
 use Cycle\Database\Exception\DefaultValueException;
+use Cycle\Database\Exception\SchemaException;
 use Cycle\Database\Injection\Fragment;
 use Cycle\Database\Injection\FragmentInterface;
 use Cycle\Database\Schema\AbstractColumn;
@@ -149,6 +150,9 @@ class MySQLColumn extends AbstractColumn
         'longblob',
         'json',
     ];
+
+    #[ColumnAttribute(['string', 'varbinary'])]
+    protected int $size = 0;
 
     /**
      * Column is auto incremental.
@@ -306,6 +310,34 @@ class MySQLColumn extends AbstractColumn
     {
         $this->type('set');
         $this->enumValues = array_map('strval', is_array($values) ? $values : func_get_args());
+
+        return $this;
+    }
+
+    /**
+     * @param positive-int|0 $size
+     */
+    public function varbinary(int $size = 255): self
+    {
+        $this->type('varbinary');
+
+        $size < 0 && throw new SchemaException('Invalid varbinary size value');
+
+        $this->size = $size;
+
+        return $this;
+    }
+
+    /**
+     * @param positive-int|0 $size
+     */
+    public function binary(int $size = 0): self
+    {
+        if ($size > 0) {
+            return $this->varbinary($size);
+        }
+
+        $this->type('blob');
 
         return $this;
     }

--- a/src/Driver/Postgres/Schema/PostgresColumn.php
+++ b/src/Driver/Postgres/Schema/PostgresColumn.php
@@ -259,7 +259,7 @@ class PostgresColumn extends AbstractColumn
         'time',
         'timetz',
         'timestamp',
-        'timestamptz'
+        'timestamptz',
     ])]
     protected int $size = 0;
 

--- a/src/Driver/Postgres/Schema/PostgresColumn.php
+++ b/src/Driver/Postgres/Schema/PostgresColumn.php
@@ -251,6 +251,9 @@ class PostgresColumn extends AbstractColumn
         'bit'          => ['bit', 'bit varying'],
     ];
 
+    #[ColumnAttribute(['string', 'bit', 'bit varying', 'datetime', 'time', 'timetz', 'timestamp', 'timestamptz'])]
+    protected int $size = 0;
+
     /**
      * Field is auto incremental.
      *

--- a/src/Driver/Postgres/Schema/PostgresColumn.php
+++ b/src/Driver/Postgres/Schema/PostgresColumn.php
@@ -251,7 +251,16 @@ class PostgresColumn extends AbstractColumn
         'bit'          => ['bit', 'bit varying'],
     ];
 
-    #[ColumnAttribute(['string', 'bit', 'bit varying', 'datetime', 'time', 'timetz', 'timestamp', 'timestamptz'])]
+    #[ColumnAttribute([
+        'character varying',
+        'bit',
+        'bit varying',
+        'datetime',
+        'time',
+        'timetz',
+        'timestamp',
+        'timestamptz'
+    ])]
     protected int $size = 0;
 
     /**

--- a/src/Driver/SQLServer/Schema/SQLServerColumn.php
+++ b/src/Driver/SQLServer/Schema/SQLServerColumn.php
@@ -120,7 +120,7 @@ class SQLServerColumn extends AbstractColumn
         'binary'      => ['varbinary'],
     ];
 
-    #[ColumnAttribute(['string', 'datetime2', 'varbinary'])]
+    #[ColumnAttribute(['varchar', 'datetime2', 'varbinary'])]
     protected int $size = 0;
 
     /**

--- a/src/Driver/SQLServer/Schema/SQLServerColumn.php
+++ b/src/Driver/SQLServer/Schema/SQLServerColumn.php
@@ -14,6 +14,7 @@ namespace Cycle\Database\Driver\SQLServer\Schema;
 use Cycle\Database\Driver\DriverInterface;
 use Cycle\Database\Exception\SchemaException;
 use Cycle\Database\Schema\AbstractColumn;
+use Cycle\Database\Schema\Attribute\ColumnAttribute;
 
 class SQLServerColumn extends AbstractColumn
 {
@@ -38,6 +39,15 @@ class SQLServerColumn extends AbstractColumn
         'defaultConstraint',
         'constrainedEnum',
         'enumConstraint',
+        'attributes',
+    ];
+
+    protected array $aliases = [
+        'int'       => 'integer',
+        'smallint'  => 'smallInteger',
+        'bigint'    => 'bigInteger',
+        'bool'      => 'boolean',
+        'varbinary' => 'binary',
     ];
 
     protected array $mapping = [
@@ -109,6 +119,9 @@ class SQLServerColumn extends AbstractColumn
         'time'        => ['time'],
         'binary'      => ['varbinary'],
     ];
+
+    #[ColumnAttribute(['string', 'datetime2', 'varbinary'])]
+    protected int $size = 0;
 
     /**
      * Field is table identity.

--- a/src/Driver/SQLite/Schema/SQLiteColumn.php
+++ b/src/Driver/SQLite/Schema/SQLiteColumn.php
@@ -13,7 +13,6 @@ namespace Cycle\Database\Driver\SQLite\Schema;
 
 use Cycle\Database\Driver\DriverInterface;
 use Cycle\Database\Schema\AbstractColumn;
-use Cycle\Database\Schema\Attribute\ColumnAttribute;
 
 class SQLiteColumn extends AbstractColumn
 {
@@ -113,9 +112,6 @@ class SQLiteColumn extends AbstractColumn
      * Indication that column is primary key.
      */
     protected bool $primaryKey = false;
-
-    #[ColumnAttribute([])]
-    protected int $size = 0;
 
     /**
      * DBMS specific reverse mapping must map database specific type into limited set of abstract

--- a/src/Driver/SQLite/Schema/SQLiteColumn.php
+++ b/src/Driver/SQLite/Schema/SQLiteColumn.php
@@ -13,6 +13,7 @@ namespace Cycle\Database\Driver\SQLite\Schema;
 
 use Cycle\Database\Driver\DriverInterface;
 use Cycle\Database\Schema\AbstractColumn;
+use Cycle\Database\Schema\Attribute\ColumnAttribute;
 
 class SQLiteColumn extends AbstractColumn
 {
@@ -112,6 +113,9 @@ class SQLiteColumn extends AbstractColumn
      * Indication that column is primary key.
      */
     protected bool $primaryKey = false;
+
+    #[ColumnAttribute([])]
+    protected int $size = 0;
 
     /**
      * DBMS specific reverse mapping must map database specific type into limited set of abstract

--- a/src/Schema/AbstractTable.php
+++ b/src/Schema/AbstractTable.php
@@ -668,7 +668,7 @@ abstract class AbstractTable implements TableInterface, ElementInterface
     }
 
     /**
-     * Ensure that no wrong indexes left in table. This method will create AbstracTable
+     * Ensure that no wrong indexes left in table. This method will create AbstractTable
      * copy in order to prevent cross modifications.
      */
     protected function normalizeSchema(bool $withForeignKeys = true): self

--- a/tests/Database/Functional/Driver/Common/Schema/JsonColumnTest.php
+++ b/tests/Database/Functional/Driver/Common/Schema/JsonColumnTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\Common\Schema;
+
+use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
+
+abstract class JsonColumnTest extends BaseTest
+{
+    public function testColumnSizeIsIgnored(): void
+    {
+        $schema = $this->schema('table');
+        $schema->primary('id');
+        $schema->json('json_data', size: 255);
+        $schema->save();
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame(0, $schema->column('json_data')->getSize());
+    }
+}

--- a/tests/Database/Functional/Driver/Common/Schema/StringColumnTest.php
+++ b/tests/Database/Functional/Driver/Common/Schema/StringColumnTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\Common\Schema;
+
+use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
+
+abstract class StringColumnTest extends BaseTest
+{
+    public function testStringDefaultSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $column = $schema->string('column');
+        $schema->save();
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame(255, $column->getSize());
+    }
+
+    public function testStringSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $column = $schema->string('column', size: 64);
+        $schema->save();
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame(64, $column->getSize());
+    }
+}

--- a/tests/Database/Functional/Driver/MySQL/Connection/CustomOptionsTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Connection/CustomOptionsTest.php
@@ -76,7 +76,7 @@ class CustomOptionsTest extends CommonClass
     {
         $schema = $this->schema('foo');
         $schema->bigPrimary('id', zerofill: true)->unsigned(true);
-        $schema->bigInteger('foo', nullable: true, unsigned: true, zerofill: true);
+        $schema->bigInteger('foo', nullable: true, unsigned: true, zerofill: true, size: 18);
         $schema->save();
 
         $this->assertInstanceOf(MySQLColumn::class, $id = $this->fetchSchema($schema)->column('id'));
@@ -89,6 +89,7 @@ class CustomOptionsTest extends CommonClass
         $this->assertTrue($id->isUnsigned());
         $this->assertTrue($foo->isUnsigned());
         $this->assertSame(20, $id->getSize());
+        $this->assertSame(18, $foo->getSize());
         $this->assertFalse($id->isNullable());
         $this->assertTrue($foo->isNullable());
     }

--- a/tests/Database/Functional/Driver/MySQL/Connection/CustomOptionsTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Connection/CustomOptionsTest.php
@@ -76,7 +76,7 @@ class CustomOptionsTest extends CommonClass
     {
         $schema = $this->schema('foo');
         $schema->bigPrimary('id', zerofill: true)->unsigned(true);
-        $schema->bigInteger('foo', nullable: true, unsigned: true, zerofill: true, size: 18);
+        $schema->bigInteger('foo', nullable: true, unsigned: true, zerofill: true);
         $schema->save();
 
         $this->assertInstanceOf(MySQLColumn::class, $id = $this->fetchSchema($schema)->column('id'));
@@ -89,7 +89,6 @@ class CustomOptionsTest extends CommonClass
         $this->assertTrue($id->isUnsigned());
         $this->assertTrue($foo->isUnsigned());
         $this->assertSame(20, $id->getSize());
-        $this->assertSame(18, $foo->getSize());
         $this->assertFalse($id->isNullable());
         $this->assertTrue($foo->isNullable());
     }

--- a/tests/Database/Functional/Driver/MySQL/Schema/BinaryColumnTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Schema/BinaryColumnTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\MySQL\Schema;
+
+use Cycle\Database\Driver\Handler;
+use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+final class BinaryColumnTest extends BaseTest
+{
+    public const DRIVER = 'mysql';
+
+    public function testBinary(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->binary('binary_data');
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('blob', $schema->column('binary_data')->getInternalType());
+        $this->assertSame(0, $schema->column('binary_data')->getSize());
+    }
+
+    public function testBinaryWithSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->binary('binary_data', 16);
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('varbinary', $schema->column('binary_data')->getInternalType());
+        $this->assertSame(16, $schema->column('binary_data')->getSize());
+    }
+
+    public function testVarbinary(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->varbinary('binary_data');
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('varbinary', $schema->column('binary_data')->getInternalType());
+        $this->assertSame(255, $schema->column('binary_data')->getSize());
+    }
+
+    public function testVarbinaryWithSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->varbinary('binary_data', 16);
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('varbinary', $schema->column('binary_data')->getInternalType());
+        $this->assertSame(16, $schema->column('binary_data')->getSize());
+    }
+}

--- a/tests/Database/Functional/Driver/MySQL/Schema/DatetimeColumnTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Schema/DatetimeColumnTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Database\Tests\Functional\Driver\MySQL\Schema;
 
 // phpcs:ignore
+use Cycle\Database\Driver\Handler;
 use Cycle\Database\Exception\HandlerException;
 use Cycle\Database\Tests\Functional\Driver\Common\Schema\DatetimeColumnTest as CommonClass;
 
@@ -24,5 +25,47 @@ class DatetimeColumnTest extends CommonClass
 
         $this->expectException(HandlerException::class);
         parent::testTimestampDatetimeZero();
+    }
+
+    public function testTimeWithSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->time('time_data', size: 3);
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('time', $schema->column('time_data')->getInternalType());
+        $this->assertSame(3, $schema->column('time_data')->getSize());
+    }
+
+    public function testTimestampWithSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->timestamp('timestamp_data', size: 3);
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('timestamp', $schema->column('timestamp_data')->getInternalType());
+        $this->assertSame(3, $schema->column('timestamp_data')->getSize());
+    }
+
+    public function testDatetimeWithSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->datetime('datetime_data', size: 3);
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('datetime', $schema->column('datetime_data')->getInternalType());
+        $this->assertSame(3, $schema->column('datetime_data')->getSize());
     }
 }

--- a/tests/Database/Functional/Driver/MySQL/Schema/JsonColumnTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Schema/JsonColumnTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\MySQL\Schema;
+
+// phpcs:ignore
+use Cycle\Database\Tests\Functional\Driver\Common\Schema\JsonColumnTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class JsonColumnTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/Database/Functional/Driver/MySQL/Schema/NumberColumnTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Schema/NumberColumnTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\MySQL\Schema;
+
+// phpcs:ignore
+use Cycle\Database\Driver\Handler;
+use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+final class NumberColumnTest extends BaseTest
+{
+    public const DRIVER = 'mysql';
+
+    public function testInteger(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->integer('integer_data');
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('int', $schema->column('integer_data')->getInternalType());
+        $this->assertSame(11, $schema->column('integer_data')->getSize());
+    }
+
+    public function testIntegerWithSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->integer('integer_data', size: 7);
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('int', $schema->column('integer_data')->getInternalType());
+        $this->assertSame(7, $schema->column('integer_data')->getSize());
+    }
+
+    public function testTinyInteger(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->tinyInteger('tiny_integer_data');
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('tinyint', $schema->column('tiny_integer_data')->getInternalType());
+        $this->assertSame(4, $schema->column('tiny_integer_data')->getSize());
+    }
+
+    public function testTinyIntegerWithSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->tinyInteger('tiny_integer_data', size: 3);
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('tinyint', $schema->column('tiny_integer_data')->getInternalType());
+        $this->assertSame(3, $schema->column('tiny_integer_data')->getSize());
+    }
+
+    public function testSmallInteger(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->smallInteger('small_integer_data');
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('smallint', $schema->column('small_integer_data')->getInternalType());
+        $this->assertSame(6, $schema->column('small_integer_data')->getSize());
+    }
+
+    public function testSmallIntegerWithSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->smallInteger('small_integer_data', size: 3);
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('smallint', $schema->column('small_integer_data')->getInternalType());
+        $this->assertSame(3, $schema->column('small_integer_data')->getSize());
+    }
+
+    public function testBigInteger(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->bigInteger('big_integer_data');
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('bigint', $schema->column('big_integer_data')->getInternalType());
+        $this->assertSame(20, $schema->column('big_integer_data')->getSize());
+    }
+
+    public function testBigIntegerWithSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->bigInteger('big_integer_data', size: 17);
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('bigint', $schema->column('big_integer_data')->getInternalType());
+        $this->assertSame(17, $schema->column('big_integer_data')->getSize());
+    }
+}

--- a/tests/Database/Functional/Driver/MySQL/Schema/StringColumnTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Schema/StringColumnTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\MySQL\Schema;
+
+// phpcs:ignore
+use Cycle\Database\Tests\Functional\Driver\Common\Schema\StringColumnTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class StringColumnTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/Database/Functional/Driver/Postgres/Schema/BinaryColumnTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Schema/BinaryColumnTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Cycle\Database\Tests\Functional\Driver\Postgres\Schema;
 
-// phpcs:ignore
 use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
 
 /**
  * @group driver
  * @group driver-postgres
  */
-final class BitColumnTest extends BaseTest
+final class BinaryColumnTest extends BaseTest
 {
     public const DRIVER = 'postgres';
 

--- a/tests/Database/Functional/Driver/Postgres/Schema/DatetimeColumnTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Schema/DatetimeColumnTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Database\Tests\Functional\Driver\Postgres\Schema;
 
 // phpcs:ignore
+use Cycle\Database\Driver\Handler;
 use Cycle\Database\Driver\Postgres\Schema\PostgresColumn;
 use Cycle\Database\Exception\SchemaException;
 use Cycle\Database\Tests\Functional\Driver\Common\Schema\DatetimeColumnTest as CommonClass;
@@ -31,6 +32,7 @@ class DatetimeColumnTest extends CommonClass
         $this->assertTrue($column->getAttributes()['withTimezone']);
         $this->assertTrue($savedColumn->getAttributes()['withTimezone']);
         $this->assertSame('timestamptz', $column->getAbstractType());
+        $this->assertSame(0, $column->getSize());
     }
 
     public function testTimestampWithTimezone(): void
@@ -81,6 +83,7 @@ class DatetimeColumnTest extends CommonClass
         $this->assertTrue($column->getAttributes()['withTimezone']);
         $this->assertTrue($savedColumn->getAttributes()['withTimezone']);
         $this->assertSame('timetz', $column->getAbstractType());
+        $this->assertSame(0, $column->getSize());
     }
 
     public function testTimestampWithoutTimezone(): void
@@ -98,6 +101,7 @@ class DatetimeColumnTest extends CommonClass
         $this->assertFalse($column->getAttributes()['withTimezone']);
         $this->assertFalse($savedColumn->getAttributes()['withTimezone']);
         $this->assertSame('timestamp', $column->getAbstractType());
+        $this->assertSame(0, $column->getSize());
     }
 
     public function testTimeWithoutTimezone(): void
@@ -214,5 +218,103 @@ class DatetimeColumnTest extends CommonClass
 
         $this->expectException(SchemaException::class);
         $schema->save();
+    }
+
+    public function testDatetime(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->datetime('datetime_data');
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('timestamp', $schema->column('datetime_data')->getInternalType());
+        $this->assertSame(0, $schema->column('datetime_data')->getSize());
+    }
+
+    public function testDatetimeWithSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->datetime('datetime_data', 6);
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('timestamp', $schema->column('datetime_data')->getInternalType());
+        $this->assertSame(6, $schema->column('datetime_data')->getSize());
+    }
+
+    public function testTime(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->time('time_data');
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('time', $schema->column('time_data')->getInternalType());
+        $this->assertSame(0, $schema->column('time_data')->getSize());
+    }
+
+    public function testTimeWithSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->time('time_data', size: 6);
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('time', $schema->column('time_data')->getInternalType());
+        $this->assertSame(6, $schema->column('time_data')->getSize());
+    }
+
+    public function testTimeTzWithSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->timetz('time_data', size: 6);
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('time', $schema->column('time_data')->getInternalType());
+        $this->assertSame(6, $schema->column('time_data')->getSize());
+    }
+
+    public function testTimestampWithSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->timestamp('timestamp_data', size: 6);
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('timestamp', $schema->column('timestamp_data')->getInternalType());
+        $this->assertSame(6, $schema->column('timestamp_data')->getSize());
+    }
+
+    public function testTimestampTzWithSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->timestamptz('timestamp_data', size: 6);
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('timestamp', $schema->column('timestamp_data')->getInternalType());
+        $this->assertSame(6, $schema->column('timestamp_data')->getSize());
     }
 }

--- a/tests/Database/Functional/Driver/Postgres/Schema/JsonColumnTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Schema/JsonColumnTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\Postgres\Schema;
+
+// phpcs:ignore
+use Cycle\Database\Tests\Functional\Driver\Common\Schema\JsonColumnTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class JsonColumnTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/Database/Functional/Driver/Postgres/Schema/StringColumnTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Schema/StringColumnTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Cycle\Database\Tests\Functional\Driver\Postgres\Schema;
 
 // phpcs:ignore
-use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\Database\Tests\Functional\Driver\Common\Schema\StringColumnTest as CommonClass;
 
 /**
  * @group driver
  * @group driver-postgres
  */
-final class StringColumnTest extends BaseTest
+final class StringColumnTest extends CommonClass
 {
     public const DRIVER = 'postgres';
 

--- a/tests/Database/Functional/Driver/SQLServer/Schema/BinaryColumnTest.php
+++ b/tests/Database/Functional/Driver/SQLServer/Schema/BinaryColumnTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\SQLServer\Schema;
+
+use Cycle\Database\Driver\Handler;
+use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class BinaryColumnTest extends BaseTest
+{
+    public const DRIVER = 'sqlserver';
+
+    public function testBinary(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->binary('binary_data');
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('varbinary', $schema->column('binary_data')->getInternalType());
+        $this->assertSame(0, $schema->column('binary_data')->getSize());
+    }
+
+    public function testBinaryWithSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->binary('binary_data', size: 16);
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('varbinary', $schema->column('binary_data')->getInternalType());
+        $this->assertSame(16, $schema->column('binary_data')->getSize());
+    }
+
+    public function testVarbinary(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->varbinary('binary_data');
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('varbinary', $schema->column('binary_data')->getInternalType());
+        $this->assertSame(0, $schema->column('binary_data')->getSize());
+    }
+
+    public function testVarbinaryWithSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->varbinary('binary_data', size: 16);
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('varbinary', $schema->column('binary_data')->getInternalType());
+        $this->assertSame(16, $schema->column('binary_data')->getSize());
+    }
+}

--- a/tests/Database/Functional/Driver/SQLServer/Schema/DatetimeColumnTest.php
+++ b/tests/Database/Functional/Driver/SQLServer/Schema/DatetimeColumnTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Database\Tests\Functional\Driver\SQLServer\Schema;
 
 // phpcs:ignore
+use Cycle\Database\Driver\Handler;
 use Cycle\Database\Tests\Functional\Driver\Common\Schema\DatetimeColumnTest as CommonClass;
 
 /**
@@ -14,4 +15,18 @@ use Cycle\Database\Tests\Functional\Driver\Common\Schema\DatetimeColumnTest as C
 class DatetimeColumnTest extends CommonClass
 {
     public const DRIVER = 'sqlserver';
+
+    public function testDatetimeWithSize(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->datetime('datetime_data', size: 6);
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('datetime2', $schema->column('datetime_data')->getInternalType());
+        $this->assertSame(6, $schema->column('datetime_data')->getSize());
+    }
 }

--- a/tests/Database/Functional/Driver/SQLServer/Schema/JsonColumnTest.php
+++ b/tests/Database/Functional/Driver/SQLServer/Schema/JsonColumnTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\SQLServer\Schema;
+
+// phpcs:ignore
+use Cycle\Database\Tests\Functional\Driver\Common\Schema\JsonColumnTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class JsonColumnTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/Database/Functional/Driver/SQLServer/Schema/JsonColumnTest.php
+++ b/tests/Database/Functional/Driver/SQLServer/Schema/JsonColumnTest.php
@@ -14,4 +14,9 @@ use Cycle\Database\Tests\Functional\Driver\Common\Schema\JsonColumnTest as Commo
 class JsonColumnTest extends CommonClass
 {
     public const DRIVER = 'sqlserver';
+
+    public function testColumnSizeIsIgnored(): void
+    {
+        $this->markTestSkipped('SQLServer stores JSON as `varchar` and its length can be changed.');
+    }
 }

--- a/tests/Database/Functional/Driver/SQLServer/Schema/StringColumnTest.php
+++ b/tests/Database/Functional/Driver/SQLServer/Schema/StringColumnTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\SQLServer\Schema;
+
+// phpcs:ignore
+use Cycle\Database\Tests\Functional\Driver\Common\Schema\StringColumnTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class StringColumnTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/Database/Functional/Driver/SQLite/Schema/JsonColumnTest.php
+++ b/tests/Database/Functional/Driver/SQLite/Schema/JsonColumnTest.php
@@ -14,4 +14,9 @@ use Cycle\Database\Tests\Functional\Driver\Common\Schema\JsonColumnTest as Commo
 class JsonColumnTest extends CommonClass
 {
     public const DRIVER = 'sqlite';
+
+    public function testColumnSizeIsIgnored(): void
+    {
+        $this->markTestSkipped('SQLite stores JSON as `text` and its length can be changed.');
+    }
 }

--- a/tests/Database/Functional/Driver/SQLite/Schema/JsonColumnTest.php
+++ b/tests/Database/Functional/Driver/SQLite/Schema/JsonColumnTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\SQLite\Schema;
+
+// phpcs:ignore
+use Cycle\Database\Tests\Functional\Driver\Common\Schema\JsonColumnTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class JsonColumnTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}

--- a/tests/Database/Functional/Driver/SQLite/Schema/StringColumnTest.php
+++ b/tests/Database/Functional/Driver/SQLite/Schema/StringColumnTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\SQLite\Schema;
+
+// phpcs:ignore
+use Cycle\Database\Tests\Functional\Driver\Common\Schema\StringColumnTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class StringColumnTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}


### PR DESCRIPTION
### Varbinary

Support for `varbinary` in MySQL has been added with the ability to specify **size**. When specifying a binary type with size, a column of type varbinary with the required size will be automatically created. 

```php
#[Entity]
class User
{
    #[Column(type: 'binary(16)', primary: true)]
    private UuidInterface $uuid;
}
```

Prior to these changes, a column of type `blob` was created and the size was ignored.

Closes: #144 

### Size attribute

The size attribute is explicitly used in certain column types. Prior to these changes, for example, mistakenly specifying a size on a column of type json would lead to the generation of erroneous migrations.