### PR TITLE
Add a default size to the mapping

### DIFF
--- a/src/Driver/MySQL/Schema/MySQLColumn.php
+++ b/src/Driver/MySQL/Schema/MySQLColumn.php
@@ -106,6 +106,7 @@ class MySQLColumn extends AbstractColumn
         'binary'      => 'blob',
         'tinyBinary'  => 'tinyblob',
         'longBinary'  => 'longblob',
+        'varbinary'   => ['type' => 'varbinary', 'size' => 255],
 
         //Additional types
         'json'        => 'json',

--- a/src/Driver/Postgres/Schema/PostgresColumn.php
+++ b/src/Driver/Postgres/Schema/PostgresColumn.php
@@ -139,7 +139,7 @@ class PostgresColumn extends AbstractColumn
         'bigInteger'   => 'bigint',
 
         //String with specified length (mapped via method)
-        'string'       => 'character varying',
+        'string'       => ['type' => 'character varying', 'size' => 255],
 
         //Generic types
         'text'         => 'text',

--- a/src/Driver/SQLServer/Schema/SQLServerColumn.php
+++ b/src/Driver/SQLServer/Schema/SQLServerColumn.php
@@ -69,7 +69,7 @@ class SQLServerColumn extends AbstractColumn
         'bigInteger'  => 'bigint',
 
         //String with specified length (mapped via method)
-        'string'      => 'varchar',
+        'string'      => ['type' => 'varchar', 'size' => 255],
 
         //Generic types
         'text'        => ['type' => 'varchar', 'size' => 0],

--- a/src/Driver/SQLite/Schema/SQLiteColumn.php
+++ b/src/Driver/SQLite/Schema/SQLiteColumn.php
@@ -59,7 +59,7 @@ class SQLiteColumn extends AbstractColumn
         'bigInteger'  => 'bigint',
 
         //String with specified length (mapped via method)
-        'string'      => 'text',
+        'string'      => ['type' => 'text', 'size' => 255],
 
         //Generic types
         'text'        => 'text',

--- a/tests/Database/Functional/Driver/Common/Schema/StringColumnTest.php
+++ b/tests/Database/Functional/Driver/Common/Schema/StringColumnTest.php
@@ -19,6 +19,17 @@ abstract class StringColumnTest extends BaseTest
         $this->assertSame(255, $column->getSize());
     }
 
+    public function testStringDefaultSizeViaMagicMethod(): void
+    {
+        $schema = $this->schema('table');
+
+        $column = $schema->column('column')->__call('string');
+        $schema->save();
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame(255, $column->getSize());
+    }
+
     public function testStringSize(): void
     {
         $schema = $this->schema('table');

--- a/tests/Database/Functional/Driver/MySQL/Schema/BinaryColumnTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Schema/BinaryColumnTest.php
@@ -57,6 +57,20 @@ final class BinaryColumnTest extends BaseTest
         $this->assertSame(255, $schema->column('binary_data')->getSize());
     }
 
+    public function testVarbinaryDefaultSizeViaMagicMethod(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->primary('id');
+        $schema->column('binary_data')->__call('varbinary');
+        $schema->save(Handler::DO_ALL);
+
+        $this->assertSameAsInDB($schema);
+
+        $this->assertSame('varbinary', $schema->column('binary_data')->getInternalType());
+        $this->assertSame(255, $schema->column('binary_data')->getSize());
+    }
+
     public function testVarbinaryWithSize(): void
     {
         $schema = $this->schema('table');


### PR DESCRIPTION
## What was changed

This PR adds default size values to the mapping. The same value as the default value in the methods:
https://github.com/cycle/database/blob/2.x/src/Schema/AbstractColumn.php#L574
https://github.com/cycle/database/blob/2.x/src/Driver/MySQL/Schema/MySQLColumn.php#L329

## Why?

Without this change, the size is not set when creating a column by calling the `type` method:
https://github.com/cycle/database/blob/2.x/src/Schema/AbstractColumn.php#L477
