### PR TITLE
feat: extend database logger context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+v2.9.0 (27.03.2024)
+-------------------
+- Added `logInterpolatedQueries` for detailed query logging and refined `logQueryParameters` to accurately log query parameters as arrays, enhancing ORM debugging and monitoring. @lotyp (#165)
+- Improved logging with enriched context in Driver.php, including driver details and query parameters. @lotyp (#165)
+
 v2.8.1 (08.02.2024)
 -------------------
 - Fix compiling of Fragment with parameters in the returning() definition by @msmakouz (#161)

--- a/src/Config/DriverConfig.php
+++ b/src/Config/DriverConfig.php
@@ -26,6 +26,7 @@ abstract class DriverConfig
 
     protected array $defaultOptions = [
         'withDatetimeMicroseconds' => false,
+        'logInterpolatedQueries' => false,
         'logQueryParameters' => false,
     ];
 
@@ -42,6 +43,7 @@ abstract class DriverConfig
      * @param bool $readonly Disable write expressions
      * @param array{
      *     withDatetimeMicroseconds?: bool,
+     *     logInterpolatedQueries?: bool,
      *     logQueryParameters?: bool
      * } $options
      */

--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -686,11 +686,11 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
      *
      * @param float $queryStart Query start time
      * @param PDOStatement|PDOStatementInterface|null $statement Statement object
-     * @param iterable|null $parameters Query parameters
+     * @param iterable $parameters Query parameters
      *
      * @return array
      */
-    protected function defineLoggerContext(float $queryStart, PDOStatement|PDOStatementInterface|null $statement, ?iterable $parameters): array
+    protected function defineLoggerContext(float $queryStart, PDOStatement|PDOStatementInterface|null $statement, iterable $parameters = []): array
     {
         $context = [
             'driver' => $this->getType(),

--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -710,6 +710,6 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
             }
         }
 
-        return array_merge($context);
+        return $context;
     }
 }

--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -18,7 +18,6 @@ use Cycle\Database\Config\ProvidesSourceString;
 use Cycle\Database\Exception\DriverException;
 use Cycle\Database\Exception\ReadonlyConnectionException;
 use Cycle\Database\Exception\StatementException;
-use Cycle\Database\Injection\Parameter;
 use Cycle\Database\Injection\ParameterInterface;
 use Cycle\Database\NamedInterface;
 use Cycle\Database\Query\BuilderInterface;

--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -705,7 +705,7 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
             foreach ($parameters as $parameter) {
                 $context['parameters'][] = [
                     'type' => $parameter->getType(),
-                    'value' => $parameter->getValue()
+                    'value' => $parameter->getValue(),
                 ];
             }
         }

--- a/src/Query/Interpolator.php
+++ b/src/Query/Interpolator.php
@@ -137,6 +137,7 @@ final class Interpolator
      * Categorizes parameters into named and unnamed.
      *
      * @param iterable $parameters Parameters to categorize.
+     *
      * @return array An associative array with keys 'named' and 'unnamed'.
      */
     private static function categorizeParameters(iterable $parameters): array

--- a/src/Query/Interpolator.php
+++ b/src/Query/Interpolator.php
@@ -138,7 +138,7 @@ final class Interpolator
      *
      * @param iterable $parameters Parameters to categorize.
      *
-     * @return array An associative array with keys 'named' and 'unnamed'.
+     * @return array{named: array<string, mixed>, unnamed: list<mixed>} An associative array with keys 'named' and 'unnamed'.
      */
     private static function categorizeParameters(iterable $parameters): array
     {

--- a/src/Query/Interpolator.php
+++ b/src/Query/Interpolator.php
@@ -38,16 +38,7 @@ final class Interpolator
             return $query;
         }
 
-        $named = [];
-        $unnamed = [];
-
-        foreach ($parameters as $k => $v) {
-            if (\is_int($k)) {
-                $unnamed[] = $v;
-            } else {
-                $named[\ltrim($k, ':')] = $v;
-            }
-        }
+        ['named' => $named, 'unnamed' => $unnamed] = self::categorizeParameters($parameters);
 
         return \preg_replace_callback(
             '/(?<dq>"(?:\\\\\"|[^"])*")|(?<sq>\'(?:\\\\\'|[^\'])*\')|(?<ph>\\?)|(?<named>:[a-z_\\d]+)/',
@@ -82,7 +73,7 @@ final class Interpolator
      *
      * @psalm-return non-empty-string
      */
-    private static function resolveValue(mixed $parameter, array $options): string
+    public static function resolveValue(mixed $parameter, array $options): string
     {
         if ($parameter instanceof ParameterInterface) {
             return self::resolveValue($parameter->getValue(), $options);
@@ -140,5 +131,27 @@ final class Interpolator
             "\t" => '\\t',
             '\\' => '\\\\',
         ]);
+    }
+
+    /**
+     * Categorizes parameters into named and unnamed.
+     *
+     * @param iterable $parameters Parameters to categorize.
+     * @return array An associative array with keys 'named' and 'unnamed'.
+     */
+    private static function categorizeParameters(iterable $parameters): array
+    {
+        $named = [];
+        $unnamed = [];
+
+        foreach ($parameters as $k => $v) {
+            if (\is_int($k)) {
+                $unnamed[] = $v;
+            } else {
+                $named[\ltrim($k, ':')] = $v;
+            }
+        }
+
+        return ['named' => $named, 'unnamed' => $unnamed];
     }
 }

--- a/tests/Database/Unit/Driver/AbstractDriverTest.php
+++ b/tests/Database/Unit/Driver/AbstractDriverTest.php
@@ -183,11 +183,7 @@ class AbstractDriverTest extends TestCase
                         return false;
                     }
 
-                    if(!isset($context['driver'])) {
-                        return false;
-                    }
-
-                    return true;
+                    return isset($context['driver']);
                 })
             );
         $driver->setLogger($logger);

--- a/tests/Database/Unit/Driver/AbstractDriverTest.php
+++ b/tests/Database/Unit/Driver/AbstractDriverTest.php
@@ -128,7 +128,7 @@ class AbstractDriverTest extends TestCase
             ->willReturn($this->createMock(PDOStatementInterface::class));
 
         $driver = TestDriver::createWith(
-            new SQLiteDriverConfig(options: ['logQueryParameters' => true]),
+            new SQLiteDriverConfig(options: ['logInterpolatedQueries' => true]),
             $this->createMock(HandlerInterface::class),
             $this->createMock(BuilderInterface::class),
             $pdo
@@ -147,6 +147,53 @@ class AbstractDriverTest extends TestCase
         );
     }
 
+    public function testLogsQueryParameters(): void
+    {
+        $pdo = $this->createMock(PDOInterface::class);
+        $pdo
+            ->expects($this->once())
+            ->method('prepare')
+            ->willReturn($this->createMock(PDOStatementInterface::class));
+
+        $driver = TestDriver::createWith(
+            new SQLiteDriverConfig(options: [
+                'logInterpolatedQueries' => false,
+                'logQueryParameters' => true,
+            ]),
+            $this->createMock(HandlerInterface::class),
+            $this->createMock(BuilderInterface::class),
+            $pdo
+        );
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->once())
+            ->method('info')
+            ->with(
+                $this->equalTo('SELECT * FROM sample_table WHERE id IN (?, ?, ?) ORDER BY id ASC'),
+                $this->callback(function (array $context) {
+                    if (!isset($context['parameters'])) {
+                        return false;
+                    }
+
+                    $parametersAsString = array_map('strval', $context['parameters']);
+
+                    $expectedParameters = ['1', '2', '3'];
+                    if ($parametersAsString !== $expectedParameters) {
+                        return false;
+                    }
+
+                    return true;
+                })
+            );
+        $driver->setLogger($logger);
+
+        $driver->query(
+            'SELECT * FROM sample_table WHERE id IN (?, ?, ?) ORDER BY id ASC',
+            [1, 2, 3]
+        );
+    }
+
     public function testLogsWithEnabledInterpolationAndWithDatetimeMicroseconds(): void
     {
         $pdo = $this->createMock(PDOInterface::class);
@@ -156,7 +203,7 @@ class AbstractDriverTest extends TestCase
             ->willReturn($this->createMock(PDOStatementInterface::class));
 
         $driver = TestDriver::createWith(
-            new SQLiteDriverConfig(options: ['logQueryParameters' => true, 'withDatetimeMicroseconds' => true]),
+            new SQLiteDriverConfig(options: ['logInterpolatedQueries' => true, 'withDatetimeMicroseconds' => true]),
             $this->createMock(HandlerInterface::class),
             $this->createMock(BuilderInterface::class),
             $pdo

--- a/tests/Database/Unit/Driver/AbstractDriverTest.php
+++ b/tests/Database/Unit/Driver/AbstractDriverTest.php
@@ -183,6 +183,10 @@ class AbstractDriverTest extends TestCase
                         return false;
                     }
 
+                    if(!isset($context['driver'])) {
+                        return false;
+                    }
+
                     return true;
                 })
             );


### PR DESCRIPTION
## Changes

- Introduced additional options in DriverConfig for detailed logging control: `logInterpolatedQueries`. Converts query into interpolated one. (Before change, this was done using `logQueryParameters`)
- `logQueryParameters` - Now, does, what variable name says — Logs query parameters as array

- Modified statement method in Driver.php to utilize new logging options, enriching log context with driver details and query parameters.

## Rationale
These changes aim to improve the ORM's debugging and monitoring capabilities by offering detailed and configurable logging insights.

## Checklist

- Closes # -
- How was this tested:
    - Added new tests to cover context parameters and driver

    - Created example application with sample entity, fired persist to get logger output, which now looks like this:

	  - When `logInterpolatedQueries => true` and `logQueryParameters' => true`:
      ```
        [2024-03-19 21:42:14] local.INFO: INSERT INTO "posts" ("title", "content", "views", "id") VALUES ('title', 'content', 123, '018e58aa-38f9-725a-92cd-e69309ac5424') {"driver":"SQLite","elapsed":0.0006749629974365234,"rowCount":1,"parameters":["'title'","'content'","123","'018e58aa-38f9-725a-92cd-e69309ac5424'"]}
      ```

	- When `logInterpolatedQueries => false` and `logQueryParameters' => true`:
	  ```
        [2024-03-19 21:52:20] local.INFO: INSERT INTO "posts" ("title", "content", "views", "id") VALUES (?, ?, ?, ?) {"driver":"SQLite","elapsed":0.0006299018859863281,"rowCount":1,"parameters":["'title'","'content'","123","'018e58b3-7727-7185-9b1a-b8993069a367'"]}
      ```

    - Default behavior (both parameters set to `false`):
      ```
        [2024-03-19 21:54:17] local.INFO: INSERT INTO "posts" ("title", "content", "views", "id") VALUES (?, ?, ?, ?) {"driver":"SQLite","elapsed":0.0006580352783203125,"rowCount":1}
      ```

