### PR TITLE
Improved `orderBy` method.

### DIFF
--- a/src/Driver/Compiler.php
+++ b/src/Driver/Compiler.php
@@ -21,6 +21,8 @@ abstract class Compiler implements CompilerInterface
 {
     private Quoter $quoter;
 
+    protected const ORDER_OPTIONS = ['ASC', 'DESC'];
+
     /**
      * @psalm-param non-empty-string $quotes
      */
@@ -244,10 +246,18 @@ abstract class Compiler implements CompilerInterface
     {
         $result = [];
         foreach ($orderBy as $order) {
+            if ($order[1] === null) {
+                $result[] = $this->name($params, $q, $order[0]);
+                continue;
+            }
+
             $direction = \strtoupper($order[1]);
 
-            \in_array($direction, ['ASC', 'DESC']) or throw new CompilerException(
-                'Invalid sorting direction, only ASC and DESC are allowed'
+            \in_array($direction, static::ORDER_OPTIONS) or throw new CompilerException(
+                \sprintf(
+                    'Invalid sorting direction, only `%s` are allowed',
+                    \implode('`, `', static::ORDER_OPTIONS),
+                ),
             );
 
             $result[] = $this->name($params, $q, $order[0]) . ' ' . $direction;

--- a/src/Driver/Postgres/PostgresCompiler.php
+++ b/src/Driver/Postgres/PostgresCompiler.php
@@ -23,6 +23,11 @@ use Cycle\Database\Query\QueryParameters;
  */
 class PostgresCompiler extends Compiler implements CachingCompilerInterface
 {
+    protected const ORDER_OPTIONS = [
+        'ASC', 'ASC NULLS LAST', 'ASC NULLS FIRST' ,
+        'DESC', 'DESC NULLS LAST', 'DESC NULLS FIRST',
+    ];
+
     /**
      * @psalm-return non-empty-string
      */

--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -258,7 +258,7 @@ class SelectQuery extends ActiveQuery implements
             $result = $callback(
                 $select->offset($offset)->getIterator(),
                 $offset,
-                $count,
+                $count
             );
 
             // stop iteration
@@ -351,17 +351,17 @@ class SelectQuery extends ActiveQuery implements
     {
         return [
             'forUpdate' => $this->forUpdate,
-            'from' => $this->tables,
-            'join' => $this->joinTokens,
-            'columns' => $this->columns,
-            'distinct' => $this->distinct,
-            'where' => $this->whereTokens,
-            'having' => $this->havingTokens,
-            'groupBy' => $this->groupBy,
-            'orderBy' => array_values($this->orderBy),
-            'limit' => $this->limit,
-            'offset' => $this->offset,
-            'union' => $this->unionTokens,
+            'from'      => $this->tables,
+            'join'      => $this->joinTokens,
+            'columns'   => $this->columns,
+            'distinct'  => $this->distinct,
+            'where'     => $this->whereTokens,
+            'having'    => $this->havingTokens,
+            'groupBy'   => $this->groupBy,
+            'orderBy'   => array_values($this->orderBy),
+            'limit'     => $this->limit,
+            'offset'    => $this->offset,
+            'union'     => $this->unionTokens,
         ];
     }
 

--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -57,7 +57,7 @@ class SelectQuery extends ActiveQuery implements
     private ?int $offset = null;
 
     /**
-     * @param array $from    Initial set of table names.
+     * @param array $from Initial set of table names.
      * @param array $columns Initial set of columns to fetch.
      */
     public function __construct(array $from = [], array $columns = [])
@@ -129,12 +129,21 @@ class SelectQuery extends ActiveQuery implements
      *
      * $select->orderBy([
      *      'id'   => SelectQuery::SORT_DESC,
-     *      'name' => SelectQuery::SORT_ASC
+     *      'name' => SelectQuery::SORT_ASC,
+     *
+     *      // The following options below have the same effect (Direction will be ignored)
+     *      new Fragment('RAND()') => null,
+     *      new Fragment('RAND()')
      * ]);
      *
-     * @param 'ASC'|'DESC' $direction Sorting direction
+     * $select->orderBy('name', SelectQuery::SORT_ASC);
+     *
+     * $select->orderBy(new Fragment('RAND()'), null); // direction will be ignored
+     * $select->orderBy('RAND()', 'ASC NULLS LAST'); // Postgres specific directions are also supported
+     *
+     * @param 'ASC'|'DESC'|null $direction Sorting direction
      */
-    public function orderBy(string|FragmentInterface|array $expression, string $direction = self::SORT_ASC): self
+    public function orderBy(string|FragmentInterface|array $expression, ?string $direction = self::SORT_ASC): self
     {
         if (!\is_array($expression)) {
             $this->addOrder($expression, $direction);
@@ -142,6 +151,12 @@ class SelectQuery extends ActiveQuery implements
         }
 
         foreach ($expression as $nested => $dir) {
+            // support for orderBy(['RAND()']) without passing direction
+            if (\is_int($nested)) {
+                $nested = $dir;
+                $dir = null;
+            }
+
             $this->addOrder($nested, $dir);
         }
 
@@ -243,7 +258,7 @@ class SelectQuery extends ActiveQuery implements
             $result = $callback(
                 $select->offset($offset)->getIterator(),
                 $offset,
-                $count
+                $count,
             );
 
             // stop iteration
@@ -336,27 +351,27 @@ class SelectQuery extends ActiveQuery implements
     {
         return [
             'forUpdate' => $this->forUpdate,
-            'from'      => $this->tables,
-            'join'      => $this->joinTokens,
-            'columns'   => $this->columns,
-            'distinct'  => $this->distinct,
-            'where'     => $this->whereTokens,
-            'having'    => $this->havingTokens,
-            'groupBy'   => $this->groupBy,
-            'orderBy'   => array_values($this->orderBy),
-            'limit'     => $this->limit,
-            'offset'    => $this->offset,
-            'union'     => $this->unionTokens,
+            'from' => $this->tables,
+            'join' => $this->joinTokens,
+            'columns' => $this->columns,
+            'distinct' => $this->distinct,
+            'where' => $this->whereTokens,
+            'having' => $this->havingTokens,
+            'groupBy' => $this->groupBy,
+            'orderBy' => array_values($this->orderBy),
+            'limit' => $this->limit,
+            'offset' => $this->offset,
+            'union' => $this->unionTokens,
         ];
     }
 
     /**
      * @param FragmentInterface|string $field
-     * @param string                   $order Sorting direction, ASC|DESC.
+     * @param string|null $order Sorting direction, ASC|DESC|null.
      *
      * @return $this|self
      */
-    private function addOrder(string|FragmentInterface $field, string $order): self
+    private function addOrder(string|FragmentInterface $field, ?string $order): self
     {
         if (!\is_string($field)) {
             $this->orderBy[] = [$field, $order];

--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -139,7 +139,7 @@ class SelectQuery extends ActiveQuery implements
      * $select->orderBy('name', SelectQuery::SORT_ASC);
      *
      * $select->orderBy(new Fragment('RAND()'), null); // direction will be ignored
-     * $select->orderBy('RAND()', 'ASC NULLS LAST'); // Postgres specific directions are also supported
+     * $select->orderBy(new Fragment('RAND()'), 'ASC NULLS LAST'); // Postgres specific directions are also supported
      *
      * @param 'ASC'|'DESC'|null $direction Sorting direction
      */

--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -151,7 +151,7 @@ class SelectQuery extends ActiveQuery implements
         }
 
         foreach ($expression as $nested => $dir) {
-            // support for orderBy(['RAND()']) without passing direction
+            // support for orderBy([new Fragment('RAND()')]) without passing direction
             if (\is_int($nested)) {
                 $nested = $dir;
                 $dir = null;

--- a/tests/Database/Functional/Driver/Common/Query/SelectQueryTest.php
+++ b/tests/Database/Functional/Driver/Common/Query/SelectQueryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Database\Tests\Functional\Driver\Common\Query;
 
 use Cycle\Database\Exception\BuilderException;
+use Cycle\Database\Exception\CompilerException;
 use Cycle\Database\Exception\CompilerException\UnexpectedOperatorException;
 use Cycle\Database\Injection\Expression;
 use Cycle\Database\Injection\Fragment;
@@ -1698,6 +1699,28 @@ WHERE {name} = \'Antony\' AND {id} IN (SELECT{id}FROM {other}WHERE {x} = 123)',
             'SELECT * FROM {users} ORDER BY RAND() ASC',
             $select
         );
+    }
+
+    public function testOrderByNullableDirection(): void
+    {
+        $select = $this->database->select()
+            ->from(['users'])
+            ->orderBy(new Fragment('RAND()'), null);
+
+        $this->assertSameQuery(
+            'SELECT * FROM {users} ORDER BY RAND()',
+            $select
+        );
+    }
+
+    public function testOrderByWrongDirection(): void
+    {
+        $this->expectException(CompilerException::class);
+
+        $this->database->select()
+            ->from(['users'])
+            ->orderBy('column', 'FOO')
+            ->sqlStatement();
     }
 
     //Please not this example

--- a/tests/Database/Functional/Driver/MySQL/Query/SelectQueryTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Query/SelectQueryTest.php
@@ -481,4 +481,16 @@ class SelectQueryTest extends CommonClass
         );
         $this->assertSameParameters([5], $select);
     }
+
+    public function testOrderByCompileException(): void
+    {
+        $this->expectException(\Cycle\Database\Exception\CompilerException::class);
+        $this->expectExceptionMessage('Invalid sorting direction, only `ASC`, `DESC` are allowed');
+
+        $this->database
+            ->select()
+            ->from('table')
+            ->orderBy('name', 'FOO')
+            ->sqlStatement();
+    }
 }

--- a/tests/Database/Unit/Query/Tokens/SelectQueryTest.php
+++ b/tests/Database/Unit/Query/Tokens/SelectQueryTest.php
@@ -18,11 +18,17 @@ class SelectQueryTest extends TestCase
             ->from('table')
             ->columns('name', 'value')
             ->where(['name' => 'Antony'])
-            ->orWhere('id', '>', 1);
+            ->orWhere('id', '>', 1)
+            ->orderBy('name', 'ASC')
+            ->orderBy('id', 'DESC')
+            ->orderBy('RAND()', null)
+            ->orderBy([
+                'RAND()' => null,
+            ]);
 
         $this->assertSame(
             CompilerInterface::SELECT_QUERY,
-            $select->getType()
+            $select->getType(),
         );
 
         $this->assertEquals(
@@ -44,12 +50,16 @@ class SelectQueryTest extends TestCase
                 ],
                 'having' => [],
                 'groupBy' => [],
-                'orderBy' => [],
+                'orderBy' => [
+                    ['name', 'ASC'],
+                    ['id', 'DESC'],
+                    ['RAND()', null],
+                ],
                 'limit' => null,
                 'offset' => null,
                 'union' => [],
             ],
-            $select->getTokens()
+            $select->getTokens(),
         );
     }
 }

--- a/tests/Database/Unit/Query/Tokens/SelectQueryTest.php
+++ b/tests/Database/Unit/Query/Tokens/SelectQueryTest.php
@@ -23,7 +23,8 @@ class SelectQueryTest extends TestCase
             ->orderBy('id', 'DESC')
             ->orderBy('RAND()', null)
             ->orderBy([
-                'RAND()' => null,
+                'FOO()' => null,
+                'COALESCE(name, test)'
             ]);
 
         $this->assertSame(
@@ -54,6 +55,8 @@ class SelectQueryTest extends TestCase
                     ['name', 'ASC'],
                     ['id', 'DESC'],
                     ['RAND()', null],
+                    ['FOO()', null],
+                    ['COALESCE(name, test)', null],
                 ],
                 'limit' => null,
                 'offset' => null,

--- a/tests/Database/Unit/Query/Tokens/SelectQueryTest.php
+++ b/tests/Database/Unit/Query/Tokens/SelectQueryTest.php
@@ -24,7 +24,7 @@ class SelectQueryTest extends TestCase
             ->orderBy('RAND()', null)
             ->orderBy([
                 'FOO()' => null,
-                'COALESCE(name, test)'
+                'COALESCE(name, test)',
             ]);
 
         $this->assertSame(


### PR DESCRIPTION
Previously, the `orderBy` method required a direction parameter that was strictly bound to `ASC` or `DESC`.

With this update, the method can now accept a `null` direction, effectively ignoring the direction parameter. This change provides more flexibility when constructing queries, as it allows for ordering without specifying a direction, for example `RAND()`.

Here are some examples

```php
$select->orderBy(new Fragment('RAND()'), null);
```

```php
$select->orderBy([
  'id'   => SelectQuery::SORT_DESC,
  'name' => SelectQuery::SORT_ASC,
  
  // The following options below have the same effect (Direction will be ignored)
  new Fragment('RAND()') => null,
  new Fragment('RAND()')
]);
```

Additionally, this commit adds support for PostgreSQL-specific directions, namely `NULLS FIRST` and `NULLS LAST`. These options provide more control over the ordering of `null` values in the result set, which can be particularly useful when working with databases that contain nullable columns.

```php
$select->orderBy('name', 'ASC NULLS LAST');
```