### PR TITLE
Fix caching for insert queries with fragments

### DIFF
--- a/src/Driver/CompilerCache.php
+++ b/src/Driver/CompilerCache.php
@@ -121,8 +121,10 @@ final class CompilerCache implements CompilerInterface
 
             if ($value->isArray()) {
                 foreach ($value->getValue() as $child) {
-                    if ($child instanceof FragmentInterface && $child instanceof \Stringable) {
-                        $hash .= '_F_' . $child;
+                    if ($child instanceof FragmentInterface) {
+                        if ($child instanceof \Stringable) {
+                            $hash .= '_F_'. $child;
+                        }
                         continue;
                     }
 

--- a/src/Driver/CompilerCache.php
+++ b/src/Driver/CompilerCache.php
@@ -123,7 +123,7 @@ final class CompilerCache implements CompilerInterface
                 foreach ($value->getValue() as $child) {
                     if ($child instanceof FragmentInterface) {
                         if ($child instanceof \Stringable) {
-                            $hash .= '_F_'. $child;
+                            $hash .= '_F_' . $child;
                         }
                         continue;
                     }

--- a/src/Driver/CompilerCache.php
+++ b/src/Driver/CompilerCache.php
@@ -121,7 +121,8 @@ final class CompilerCache implements CompilerInterface
 
             if ($value->isArray()) {
                 foreach ($value->getValue() as $child) {
-                    if ($child instanceof FragmentInterface) {
+                    if ($child instanceof FragmentInterface && $child instanceof \Stringable) {
+                        $hash .= '_F_'. $child;
                         continue;
                     }
 

--- a/src/Driver/CompilerCache.php
+++ b/src/Driver/CompilerCache.php
@@ -122,7 +122,7 @@ final class CompilerCache implements CompilerInterface
             if ($value->isArray()) {
                 foreach ($value->getValue() as $child) {
                     if ($child instanceof FragmentInterface && $child instanceof \Stringable) {
-                        $hash .= '_F_'. $child;
+                        $hash .= '_F_' . $child;
                         continue;
                     }
 

--- a/tests/Database/Functional/Driver/Common/Query/InsertQueryTest.php
+++ b/tests/Database/Functional/Driver/Common/Query/InsertQueryTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Cycle\Database\Tests\Functional\Driver\Common\Query;
 
+use Cycle\Database\Driver\CompilerInterface;
 use Cycle\Database\Injection\Expression;
 use Cycle\Database\Injection\Fragment;
+use Cycle\Database\Injection\FragmentInterface;
 use Cycle\Database\Query\InsertQuery;
 use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
 
@@ -152,5 +154,38 @@ abstract class InsertQueryTest extends BaseTest
             'INSERT INTO {table} ({name}, {updated_at}, {deleted_at}) VALUES (?, NOW(), datetime(\'now\'))',
             $insert,
         );
+    }
+
+    public function testInsertWithCustomFragment(): void
+    {
+        $fragment = $this->createMock(FragmentInterface::class);
+        $fragment->method('getType')->willReturn(CompilerInterface::FRAGMENT);
+        $fragment->method('getTokens')->willReturn([
+            'fragment' => 'NOW()',
+            'parameters' => [],
+        ]);
+
+        $insert = $this->database->insert()->into('table')->values([
+            'name' => 'Anton',
+            'updated_at' => $fragment,
+        ]);
+
+        $this->assertSameQuery(
+            'INSERT INTO {table} ({name}, {updated_at}) VALUES (?, NOW())',
+            $insert
+        );
+        $this->assertSameParameters(['Anton'], $insert);
+
+        // cached query
+        $insert = $this->database->insert()->into('table')->values([
+            'name' => 'Anton',
+            'updated_at' => $fragment,
+        ]);
+
+        $this->assertSameQuery(
+            'INSERT INTO {table} ({name}, {updated_at}) VALUES (?, NOW())',
+            $insert
+        );
+        $this->assertSameParameters(['Anton'], $insert);
     }
 }

--- a/tests/Database/Functional/Driver/Common/Query/InsertQueryTest.php
+++ b/tests/Database/Functional/Driver/Common/Query/InsertQueryTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Cycle\Database\Tests\Functional\Driver\Common\Query;
 
+use Cycle\Database\Injection\Expression;
+use Cycle\Database\Injection\Fragment;
 use Cycle\Database\Query\InsertQuery;
 use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
 
@@ -97,6 +99,58 @@ abstract class InsertQueryTest extends BaseTest
         $this->assertSameQuery(
             'INSERT INTO {table} ({name}, {balance}) VALUES (?, ?), (?, ?)',
             $insert
+        );
+    }
+
+    public function testInsertWithExpressions(): void
+    {
+        $insert = $this->database->insert()->into('table')->values([
+            'name' => 'Anton',
+            'updated_at' => new Expression('NOW()'),
+            'deleted_at' => new Expression('NOW()'),
+        ]);
+
+        $this->assertSameQuery(
+            'INSERT INTO {table} ({name}, {updated_at}, {deleted_at}) VALUES (?, NOW(), NOW())',
+            $insert
+        );
+        $this->assertSameParameters(['Anton'], $insert);
+
+        $insert = $this->database->insert()->into('table')->values([
+            'name' => 'Anton',
+            'updated_at' => new Expression('NOW()'),
+            'deleted_at' => null,
+        ]);
+
+        $this->assertSameQuery(
+            'INSERT INTO {table} ({name}, {updated_at}, {deleted_at}) VALUES (?, NOW(), ?)',
+            $insert,
+        );
+        $this->assertSameParameters(['Anton', null], $insert);
+    }
+
+    public function testInsertWithFragmentsThatHaveDifferentStatements(): void
+    {
+        $insert = $this->database->insert()->into('table')->values([
+            'name' => 'Anton',
+            'updated_at' => new Fragment('NOW()'),
+            'deleted_at' => new Fragment('NOW()'),
+        ]);
+
+        $this->assertSameQuery(
+            'INSERT INTO {table} ({name}, {updated_at}, {deleted_at}) VALUES (?, NOW(), NOW())',
+            $insert
+        );
+
+        $insert = $this->database->insert()->into('table')->values([
+            'name' => 'Anton',
+            'updated_at' => new Fragment('NOW()'),
+            'deleted_at' => new Fragment('datetime(\'now\')'),
+        ]);
+
+        $this->assertSameQuery(
+            'INSERT INTO {table} ({name}, {updated_at}, {deleted_at}) VALUES (?, NOW(), datetime(\'now\'))',
+            $insert,
         );
     }
 }


### PR DESCRIPTION
## What's was changed

The caching of insert queries with fragments has been fixed.

The hash of the cached query did not take into account the number of fragments used in the query. That is, if in the first query we use two fragments, its hash is generated and we save the generated query:

```php
$insert = $database->insert()->into('table')->values([
    'name' => 'John Doe',
    'updated_at' => new Expression('NOW()'),
    'deleted_at' => new Expression('NOW()'),
]);
```

Then comes a query where the number of fragments is different; its generated hash will be the same, but the generated SQL will be different:

```php
$insert = $database->insert()->into('table')->values([
    'name' => 'John Doe',
    'updated_at' => new Expression('NOW()'),
    'deleted_at' => null,
]);
```

Another situation may occur where the number of fragments is the same, but their content is different. This has been fixed. **Now the query hash takes into account the fragments and their content.**

Closes: #176 