### PR TITLE
Adding support JSON columns in orderBy statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 v2.10.0 (01.04.2024)
 --------------------
+- Add support **JSON** columns in **orderBy** statement by @msmakouz (#184)
 - Add `mediumText` column type by @msmakouz (#178)
 - Fix caching of SQL insert query with Fragment values by @msmakouz (#177)
 - Fix detection of enum values in PostgreSQL when a enum field has only one value by @msmakouz (#181)

--- a/src/Driver/Compiler.php
+++ b/src/Driver/Compiler.php
@@ -22,7 +22,6 @@ abstract class Compiler implements CompilerInterface
     private Quoter $quoter;
 
     protected const ORDER_OPTIONS = ['ASC', 'DESC'];
-    private const JSON_SELECTOR = '->';
 
     /**
      * @psalm-param non-empty-string $quotes
@@ -247,7 +246,7 @@ abstract class Compiler implements CompilerInterface
     {
         $result = [];
         foreach ($orderBy as $order) {
-            if (\is_string($order[0]) && $this->isJsonSelector($order[0])) {
+            if (\is_string($order[0]) && $this->isJsonPath($order[0])) {
                 $order[0] = $this->compileJsonOrderBy($order[0]);
             }
 
@@ -536,9 +535,9 @@ abstract class Compiler implements CompilerInterface
         return $prefix . $expression . $postfix;
     }
 
-    protected function isJsonSelector(string $selector): bool
+    protected function isJsonPath(string $selector): bool
     {
-        return \str_contains($selector, self::JSON_SELECTOR);
+        return \str_contains($selector, '->');
     }
 
     /**

--- a/src/Driver/Compiler.php
+++ b/src/Driver/Compiler.php
@@ -535,9 +535,9 @@ abstract class Compiler implements CompilerInterface
         return $prefix . $expression . $postfix;
     }
 
-    protected function isJsonPath(string $selector): bool
+    protected function isJsonPath(string $column): bool
     {
-        return \str_contains($selector, '->');
+        return \str_contains($column, '->');
     }
 
     /**

--- a/src/Driver/Compiler.php
+++ b/src/Driver/Compiler.php
@@ -22,6 +22,7 @@ abstract class Compiler implements CompilerInterface
     private Quoter $quoter;
 
     protected const ORDER_OPTIONS = ['ASC', 'DESC'];
+    private const JSON_SELECTOR = '->';
 
     /**
      * @psalm-param non-empty-string $quotes
@@ -246,6 +247,10 @@ abstract class Compiler implements CompilerInterface
     {
         $result = [];
         foreach ($orderBy as $order) {
+            if (\is_string($order[0]) && $this->isJsonSelector($order[0])) {
+                $order[0] = $this->compileJsonOrderBy($order[0]);
+            }
+
             if ($order[1] === null) {
                 $result[] = $this->name($params, $q, $order[0]);
                 continue;
@@ -529,6 +534,19 @@ abstract class Compiler implements CompilerInterface
         }
 
         return $prefix . $expression . $postfix;
+    }
+
+    protected function isJsonSelector(string $selector): bool
+    {
+        return \str_contains($selector, self::JSON_SELECTOR);
+    }
+
+    /**
+     * Each driver must override this method and implement sorting by JSON column.
+     */
+    protected function compileJsonOrderBy(string $path): string|FragmentInterface
+    {
+        return $path;
     }
 
     private function arrayToInOperator(QueryParameters $params, Quoter $q, array $values, bool $in): string

--- a/src/Driver/MySQL/MySQLCompiler.php
+++ b/src/Driver/MySQL/MySQLCompiler.php
@@ -13,7 +13,9 @@ namespace Cycle\Database\Driver\MySQL;
 
 use Cycle\Database\Driver\CachingCompilerInterface;
 use Cycle\Database\Driver\Compiler;
+use Cycle\Database\Driver\MySQL\Injection\CompileJson;
 use Cycle\Database\Driver\Quoter;
+use Cycle\Database\Injection\FragmentInterface;
 use Cycle\Database\Injection\Parameter;
 use Cycle\Database\Query\QueryParameters;
 
@@ -68,5 +70,10 @@ class MySQLCompiler extends Compiler implements CachingCompilerInterface
         }
 
         return trim($statement);
+    }
+
+    protected function compileJsonOrderBy(string $path): FragmentInterface
+    {
+        return new CompileJson($path);
     }
 }

--- a/src/Driver/Postgres/PostgresCompiler.php
+++ b/src/Driver/Postgres/PostgresCompiler.php
@@ -13,6 +13,7 @@ namespace Cycle\Database\Driver\Postgres;
 
 use Cycle\Database\Driver\CachingCompilerInterface;
 use Cycle\Database\Driver\Compiler;
+use Cycle\Database\Driver\Postgres\Injection\CompileJson;
 use Cycle\Database\Driver\Quoter;
 use Cycle\Database\Injection\FragmentInterface;
 use Cycle\Database\Injection\Parameter;
@@ -86,5 +87,10 @@ class PostgresCompiler extends Compiler implements CachingCompilerInterface
         }
 
         return trim($statement);
+    }
+
+    protected function compileJsonOrderBy(string $path): FragmentInterface
+    {
+        return new CompileJson($path);
     }
 }

--- a/src/Driver/SQLServer/SQLServerCompiler.php
+++ b/src/Driver/SQLServer/SQLServerCompiler.php
@@ -13,6 +13,7 @@ namespace Cycle\Database\Driver\SQLServer;
 
 use Cycle\Database\Driver\Compiler;
 use Cycle\Database\Driver\Quoter;
+use Cycle\Database\Driver\SQLServer\Injection\CompileJson;
 use Cycle\Database\Injection\Fragment;
 use Cycle\Database\Injection\FragmentInterface;
 use Cycle\Database\Injection\Parameter;
@@ -156,6 +157,11 @@ class SQLServerCompiler extends Compiler
         }
 
         return $statement;
+    }
+
+    protected function compileJsonOrderBy(string $path): FragmentInterface
+    {
+        return new CompileJson($path);
     }
 
     /**

--- a/src/Driver/SQLite/SQLiteCompiler.php
+++ b/src/Driver/SQLite/SQLiteCompiler.php
@@ -14,7 +14,9 @@ namespace Cycle\Database\Driver\SQLite;
 use Cycle\Database\Driver\CachingCompilerInterface;
 use Cycle\Database\Driver\Compiler;
 use Cycle\Database\Driver\Quoter;
+use Cycle\Database\Driver\SQLite\Injection\CompileJson;
 use Cycle\Database\Exception\CompilerException;
+use Cycle\Database\Injection\FragmentInterface;
 use Cycle\Database\Injection\Parameter;
 use Cycle\Database\Injection\ParameterInterface;
 use Cycle\Database\Query\QueryParameters;
@@ -120,5 +122,10 @@ class SQLiteCompiler extends Compiler implements CachingCompilerInterface
         }
 
         return implode("\n", $statement);
+    }
+
+    protected function compileJsonOrderBy(string $path): FragmentInterface
+    {
+        return new CompileJson($path);
     }
 }

--- a/tests/Database/Functional/Driver/MySQL/Query/SelectQueryTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Query/SelectQueryTest.php
@@ -493,4 +493,17 @@ class SelectQueryTest extends CommonClass
             ->orderBy('name', 'FOO')
             ->sqlStatement();
     }
+
+    public function testOrderByJson(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from('table')
+            ->orderBy('logs->created_at', 'DESC');
+
+        $this->assertSameQuery(
+            "SELECT * FROM {table} ORDER BY json_unquote(json_extract({logs}, '$.\"created_at\"')) DESC",
+            $select
+        );
+    }
 }

--- a/tests/Database/Functional/Driver/Postgres/Query/SelectQueryTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Query/SelectQueryTest.php
@@ -503,4 +503,14 @@ class SelectQueryTest extends CommonClass
             ->orderBy('name', 'FOO')
             ->sqlStatement();
     }
+
+    public function testOrderByJson(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from('table')
+            ->orderBy('logs->created_at', 'DESC');
+
+        $this->assertSameQuery("SELECT * FROM {table} ORDER BY {logs}->>'created_at' DESC", $select);
+    }
 }

--- a/tests/Database/Functional/Driver/SQLServer/Query/SelectQueryTest.php
+++ b/tests/Database/Functional/Driver/SQLServer/Query/SelectQueryTest.php
@@ -548,4 +548,17 @@ class SelectQueryTest extends CommonClass
         );
         $this->assertSameParameters([5], $select);
     }
+
+    public function testOrderByJson(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from('table')
+            ->orderBy('logs->created_at', 'DESC');
+
+        $this->assertSameQuery(
+            "SELECT * FROM {table} ORDER BY json_value({logs}, '$.\"created_at\"') DESC",
+            $select
+        );
+    }
 }

--- a/tests/Database/Functional/Driver/SQLite/Query/SelectQueryTest.php
+++ b/tests/Database/Functional/Driver/SQLite/Query/SelectQueryTest.php
@@ -328,4 +328,17 @@ class SelectQueryTest extends CommonClass
         );
         $this->assertSameParameters([5], $select);
     }
+
+    public function testOrderByJson(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from('table')
+            ->orderBy('logs->created_at', 'DESC');
+
+        $this->assertSameQuery(
+            "SELECT * FROM {table} ORDER BY json_extract({logs}, '$.\"created_at\"') DESC",
+            $select
+        );
+    }
 }

--- a/tests/Database/Unit/Driver/CompilerTest.php
+++ b/tests/Database/Unit/Driver/CompilerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Unit\Driver;
+
+use Cycle\Database\Driver\Compiler;
+use Cycle\Database\Driver\Quoter;
+use Cycle\Database\Query\QueryParameters;
+use PHPUnit\Framework\TestCase;
+
+final class CompilerTest extends TestCase
+{
+    public function testCompileJsonOrderByShouldReturnOriginalStatement(): void
+    {
+        $compiler = new class extends Compiler {
+            protected function limit(QueryParameters $params, Quoter $q, int $limit = null, int $offset = null): string
+            {
+            }
+        };
+
+        $ref = new \ReflectionMethod($compiler, 'compileJsonOrderBy');
+        $ref->setAccessible(true);
+
+        $this->assertSame('foo-bar', $ref->invoke($compiler, 'foo-bar'));
+    }
+}

--- a/tests/Database/Unit/Driver/CompilerTest.php
+++ b/tests/Database/Unit/Driver/CompilerTest.php
@@ -13,7 +13,7 @@ final class CompilerTest extends TestCase
 {
     public function testCompileJsonOrderByShouldReturnOriginalStatement(): void
     {
-        $compiler = new class extends Compiler {
+        $compiler = new class () extends Compiler {
             protected function limit(QueryParameters $params, Quoter $q, int $limit = null, int $offset = null): string
             {
             }


### PR DESCRIPTION
## What's was changed

Adding support `JSON` columns in `orderBy` statement. For example:

```php
$records = $this->database
    ->select()
    ->from('app_logs')
    ->orderBy('record->created_at', 'DESC')
    ->fetchAll();
```

Closes: #166 