### PR TITLE
Add INTERSECT and EXCEPT operators

### DIFF
--- a/src/Driver/CompilerCache.php
+++ b/src/Driver/CompilerCache.php
@@ -210,6 +210,28 @@ final class CompilerCache implements CompilerInterface
             $hash .= $union[1];
         }
 
+        foreach ($tokens['intersect'] as $intersect) {
+            $hash .= $intersect[0];
+            if ($intersect[1] instanceof SelectQuery) {
+                $hash .= $intersect[1]->getPrefix() === null ? '' : 'i_' . $intersect[1]->getPrefix();
+                $hash .= $this->hashSelectQuery($params, $intersect[1]->getTokens());
+                continue;
+            }
+
+            $hash .= $intersect[1];
+        }
+
+        foreach ($tokens['except'] as $except) {
+            $hash .= $except[0];
+            if ($except[1] instanceof SelectQuery) {
+                $hash .= $except[1]->getPrefix() === null ? '' : 'e_' . $except[1]->getPrefix();
+                $hash .= $this->hashSelectQuery($params, $except[1]->getTokens());
+                continue;
+            }
+
+            $hash .= $except[1];
+        }
+
         return $hash;
     }
 

--- a/src/Driver/SQLServer/SQLServerCompiler.php
+++ b/src/Driver/SQLServer/SQLServerCompiler.php
@@ -179,7 +179,7 @@ class SQLServerCompiler extends Compiler
         }
 
         return sprintf(
-            "SELECT%s %s\nFROM %s%s%s%s%s%s%s%s%s",
+            "SELECT%s %s\nFROM %s%s%s%s%s%s%s%s%s%s%s",
             $this->optional(' ', $this->distinct($params, $q, $tokens['distinct'])),
             $this->columns($params, $q, $tokens['columns']),
             implode(', ', $tables),
@@ -189,6 +189,8 @@ class SQLServerCompiler extends Compiler
             $this->optional("\nGROUP BY", $this->groupBy($params, $q, $tokens['groupBy']), ' '),
             $this->optional("\nHAVING", $this->where($params, $q, $tokens['having'])),
             $this->optional("\n", $this->unions($params, $q, $tokens['union'])),
+            $this->optional("\n", $this->intersects($params, $q, $tokens['intersect'])),
+            $this->optional("\n", $this->excepts($params, $q, $tokens['except'])),
             $this->optional("\nORDER BY", $this->orderBy($params, $q, $tokens['orderBy'])),
             $this->optional("\n", $this->limit($params, $q, $tokens['limit'], $tokens['offset']))
         );

--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -404,8 +404,8 @@ class SelectQuery extends ActiveQuery implements
             'limit'     => $this->limit,
             'offset'    => $this->offset,
             'union'     => $this->unionTokens,
-            'intersect'     => $this->intersectTokens,
-            'except'     => $this->exceptTokens,
+            'intersect' => $this->intersectTokens,
+            'except'    => $this->exceptTokens,
         ];
     }
 

--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -46,6 +46,8 @@ class SelectQuery extends ActiveQuery implements
 
     protected array $tables = [];
     protected array $unionTokens = [];
+    protected array $exceptTokens = [];
+    protected array $intersectTokens = [];
     protected bool|string|array $distinct = false;
     protected array $columns = ['*'];
     /** @var FragmentInterface[][]|string[][] */
@@ -189,6 +191,46 @@ class SelectQuery extends ActiveQuery implements
     public function unionAll(FragmentInterface $query): self
     {
         $this->unionTokens[] = ['ALL', $query];
+
+        return $this;
+    }
+
+    /**
+     * Add select query to be intersected with.
+     */
+    public function intersect(FragmentInterface $query): self
+    {
+        $this->intersectTokens[] = ['', $query];
+
+        return $this;
+    }
+
+    /**
+     * Add select query to be intersected with. Duplicate values will be included in result.
+     */
+    public function intersectAll(FragmentInterface $query): self
+    {
+        $this->intersectTokens[] = ['ALL', $query];
+
+        return $this;
+    }
+
+    /**
+     * Add select query to be excepted with.
+     */
+    public function except(FragmentInterface $query): self
+    {
+        $this->exceptTokens[] = ['', $query];
+
+        return $this;
+    }
+
+    /**
+     * Add select query to be excepted with. Duplicate values will be included in result.
+     */
+    public function exceptAll(FragmentInterface $query): self
+    {
+        $this->exceptTokens[] = ['ALL', $query];
 
         return $this;
     }
@@ -362,6 +404,8 @@ class SelectQuery extends ActiveQuery implements
             'limit'     => $this->limit,
             'offset'    => $this->offset,
             'union'     => $this->unionTokens,
+            'intersect'     => $this->intersectTokens,
+            'except'     => $this->exceptTokens,
         ];
     }
 

--- a/tests/Database/Functional/Driver/Common/Query/NestedQueriesTest.php
+++ b/tests/Database/Functional/Driver/Common/Query/NestedQueriesTest.php
@@ -335,6 +335,218 @@ abstract class NestedQueriesTest extends BaseTest
         );
     }
 
+    public function testIntersectWithPrefixes(): void
+    {
+        $select = $this->db('prefixed', 'prefix_')
+            ->select('*')
+            ->from('table AS u')
+            ->where('type', 'user')->orWhere('table.id', '<', 100);
+
+        $select->intersect(
+            $this->db('prefixed', 'prefix_2_')
+                ->select('*')
+                ->from('table AS u')
+                ->where('type', 'admin')->orWhere('table.id', '>', 800)
+        );
+
+        $this->assertSameQuery(
+            'SELECT * FROM {prefix_table} AS {u} WHERE {type} = ? OR {prefix_table}.{id} < ?
+                     INTERSECT
+                     (SELECT * FROM {prefix_2_table} AS {u} WHERE {type} = ? OR {prefix_2_table}.{id} > ?)',
+            $select
+        );
+
+        $this->assertSameParameters(
+            [
+                'user',
+                100,
+                'admin',
+                800,
+            ],
+            $select
+        );
+    }
+
+    public function testIntersectWithPrefixes1(): void
+    {
+        $select = $this->db('prefixed', 'prefix_')
+            ->select('*')
+            ->from('table AS u')
+            ->where('type', 'user')->orWhere('table.id', '<', 100);
+
+        $select->intersectAll(
+            $this->db('prefixed', 'prefix_2_')
+                ->select('*')
+                ->from('table AS u')
+                ->where('type', 'admin')->orWhere('table.id', '>', 800)
+        );
+
+        $this->assertSameQuery(
+            'SELECT * FROM {prefix_table} AS {u} WHERE {type} = ? OR {prefix_table}.{id} < ?
+                     INTERSECT ALL
+                     (SELECT * FROM {prefix_2_table} AS {u} WHERE {type} = ? OR {prefix_2_table}.{id} > ?)',
+            $select
+        );
+
+        $this->assertSameParameters(
+            [
+                'user',
+                100,
+                'admin',
+                800,
+            ],
+            $select
+        );
+    }
+
+    public function testIntersectWithPrefixes2(): void
+    {
+        $select = $this->db('prefixed', 'prefix_')
+            ->select('*')
+            ->from('table AS u')
+            ->where('type', 'user')->orWhere('table.id', '<', 100);
+
+        $select->intersect(
+            $this->db('prefixed', 'prefix_2_')
+                ->select('*')
+                ->from('table AS u')
+                ->where('type', 'admin')->orWhere('table.id', '>', 800)
+        );
+
+        $select->intersectAll(
+            $this->db('prefixed', 'prefix_3_')->select('*')
+                ->from('table')->where('x', 'IN', new Parameter([8, 9, 10]))
+        );
+
+        $this->assertSameQuery(
+            'SELECT * FROM {prefix_table} AS {u} WHERE {type} = ? OR {prefix_table}.{id} < ?
+                     INTERSECT
+                     (SELECT * FROM {prefix_2_table} AS {u} WHERE {type} = ? OR {prefix_2_table}.{id} > ?)
+                     INTERSECT ALL
+                     (SELECT * FROM {prefix_3_table} WHERE {x} IN (?, ?, ?))',
+            $select
+        );
+
+        $this->assertSameParameters(
+            [
+                'user',
+                100,
+                'admin',
+                800,
+                8,
+                9,
+                10,
+            ],
+            $select
+        );
+    }
+
+    public function testExceptWithPrefixes(): void
+    {
+        $select = $this->db('prefixed', 'prefix_')
+            ->select('*')
+            ->from('table AS u')
+            ->where('type', 'user')->orWhere('table.id', '<', 100);
+
+        $select->except(
+            $this->db('prefixed', 'prefix_2_')
+                ->select('*')
+                ->from('table AS u')
+                ->where('type', 'admin')->orWhere('table.id', '>', 800)
+        );
+
+        $this->assertSameQuery(
+            'SELECT * FROM {prefix_table} AS {u} WHERE {type} = ? OR {prefix_table}.{id} < ?
+                     EXCEPT
+                     (SELECT * FROM {prefix_2_table} AS {u} WHERE {type} = ? OR {prefix_2_table}.{id} > ?)',
+            $select
+        );
+
+        $this->assertSameParameters(
+            [
+                'user',
+                100,
+                'admin',
+                800,
+            ],
+            $select
+        );
+    }
+
+    public function testExceptWithPrefixes1(): void
+    {
+        $select = $this->db('prefixed', 'prefix_')
+            ->select('*')
+            ->from('table AS u')
+            ->where('type', 'user')->orWhere('table.id', '<', 100);
+
+        $select->exceptAll(
+            $this->db('prefixed', 'prefix_2_')
+                ->select('*')
+                ->from('table AS u')
+                ->where('type', 'admin')->orWhere('table.id', '>', 800)
+        );
+
+        $this->assertSameQuery(
+            'SELECT * FROM {prefix_table} AS {u} WHERE {type} = ? OR {prefix_table}.{id} < ?
+                     EXCEPT ALL
+                     (SELECT * FROM {prefix_2_table} AS {u} WHERE {type} = ? OR {prefix_2_table}.{id} > ?)',
+            $select
+        );
+
+        $this->assertSameParameters(
+            [
+                'user',
+                100,
+                'admin',
+                800,
+            ],
+            $select
+        );
+    }
+
+    public function testExceptWithPrefixes2(): void
+    {
+        $select = $this->db('prefixed', 'prefix_')
+            ->select('*')
+            ->from('table AS u')
+            ->where('type', 'user')->orWhere('table.id', '<', 100);
+
+        $select->except(
+            $this->db('prefixed', 'prefix_2_')
+                ->select('*')
+                ->from('table AS u')
+                ->where('type', 'admin')->orWhere('table.id', '>', 800)
+        );
+
+        $select->exceptAll(
+            $this->db('prefixed', 'prefix_3_')->select('*')
+                ->from('table')->where('x', 'IN', new Parameter([8, 9, 10]))
+        );
+
+        $this->assertSameQuery(
+            'SELECT * FROM {prefix_table} AS {u} WHERE {type} = ? OR {prefix_table}.{id} < ?
+                     EXCEPT
+                     (SELECT * FROM {prefix_2_table} AS {u} WHERE {type} = ? OR {prefix_2_table}.{id} > ?)
+                     EXCEPT ALL
+                     (SELECT * FROM {prefix_3_table} WHERE {x} IN (?, ?, ?))',
+            $select
+        );
+
+        $this->assertSameParameters(
+            [
+                'user',
+                100,
+                'admin',
+                800,
+                8,
+                9,
+                10,
+            ],
+            $select
+        );
+    }
+
     public function testSubQueryInUpdate(): void
     {
         $select = $this->database->update()

--- a/tests/Database/Unit/Query/Tokens/SelectQueryTest.php
+++ b/tests/Database/Unit/Query/Tokens/SelectQueryTest.php
@@ -61,6 +61,8 @@ class SelectQueryTest extends TestCase
                 'limit' => null,
                 'offset' => null,
                 'union' => [],
+                'intersect' => [],
+                'except' => [],
             ],
             $select->getTokens(),
         );


### PR DESCRIPTION
## 🔍 What was changed

Add INTERSECT, INTERSECT ALL, EXCEPT, EXCEPT ALL.
Methods was copied from UNION and UNION ALL operators


## 🤔 Why?

Because its nice sql operators

- Closes #
- How was this tested:
  - [X] Tested manually
  - [X] Unit tests added

