### PR TITLE
feat: add the ability to specify the full name of the join type

### DIFF
--- a/src/Driver/Compiler.php
+++ b/src/Driver/Compiler.php
@@ -206,7 +206,7 @@ abstract class Compiler implements CompilerInterface
         $statement = '';
         foreach ($joins as $join) {
             $statement .= sprintf(
-                "\n%s JOIN %s",
+                \str_contains($join['type'], 'JOIN') ? "\n%s %s" : "\n%s JOIN %s",
                 $join['type'],
                 $this->nameWithAlias($params, $q, $join['outer'], $join['alias'], true)
             );

--- a/src/Driver/CompilerCache.php
+++ b/src/Driver/CompilerCache.php
@@ -171,7 +171,7 @@ final class CompilerCache implements CompilerInterface
         $hash .= $this->hashColumns($params, $tokens['columns']);
 
         foreach ($tokens['join'] as $join) {
-            $hash .= 'j' . $join['alias'] . $join['type'];
+            $hash .= 'j' . $join['alias'] . \str_replace(['JOIN', ' '], '', $join['type']);
 
             if ($join['outer'] instanceof SelectQuery) {
                 $hash .= $join['outer']->getPrefix() === null ? '' : 'p_' . $join['outer']->getPrefix();

--- a/tests/Database/Functional/Driver/Common/Query/SelectWithJoinQueryTest.php
+++ b/tests/Database/Functional/Driver/Common/Query/SelectWithJoinQueryTest.php
@@ -368,6 +368,28 @@ abstract class SelectWithJoinQueryTest extends BaseTest
         );
     }
 
+    public function testJoinWithFullTypeName(): void
+    {
+        $select = $this->database->select()
+            ->from('temperature as t')
+            ->where('t.date', '2022-01-05')
+            ->join(
+                type: 'LEFT JOIN LATERAL',
+                outer: $this->database->select()
+                    ->from('humidity')
+                    ->where('h.date', '<=', 't.date'),
+                alias: 'h',
+                on: new Fragment('true')
+            );
+
+        $this->assertSameQuery(
+            'SELECT * FROM {temperature} AS {t}
+            LEFT JOIN LATERAL (SELECT * FROM {humidity} WHERE {h}.{date} <= ?) AS {h}
+            ON true WHERE {t}.{date} = ?',
+            $select
+        );
+    }
+
     //Join with WHERE
 
     public function testJoinOnWhereParameterOrder(): void

--- a/tests/Database/Functional/Driver/Postgres/Query/SelectWithJoinQueryTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Query/SelectWithJoinQueryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Database\Tests\Functional\Driver\Postgres\Query;
 
 // phpcs:ignore
+use Cycle\Database\Injection\Fragment;
 use Cycle\Database\Tests\Functional\Driver\Common\Query\SelectWithJoinQueryTest as CommonClass;
 
 /**
@@ -14,4 +15,33 @@ use Cycle\Database\Tests\Functional\Driver\Common\Query\SelectWithJoinQueryTest 
 class SelectWithJoinQueryTest extends CommonClass
 {
     public const DRIVER = 'postgres';
+
+    public function testCacheLeftJoinLateral(): void
+    {
+        $compiler = $this->database->select()->getDriver()->getQueryCompiler();
+
+        $ref = new \ReflectionProperty($compiler, 'cache');
+        $ref->setAccessible(true);
+        $ref->setValue($compiler, []);
+
+        $select = $this->database->select()
+            ->from('temperature as t')
+            ->where('t.date', '2022-01-05')
+            ->join(
+                type: 'LEFT JOIN LATERAL',
+                outer: $this->database->select()
+                    ->from('humidity')
+                    ->where('h.date', '<=', 't.date'),
+                alias: 'h',
+                on: new Fragment('true')
+            );
+
+        $select->sqlStatement();
+
+        // Verify that the join name has a correct format in the cache
+        $this->assertArrayHasKey(
+            's__temperature as t*,jhLEFTLATERALp_s__humidity*,wANDh.date<=?_1_1onANDtruewANDt.date=?_1_1',
+            $ref->getValue($compiler)
+        );
+    }
 }


### PR DESCRIPTION
## 🔍 What was changed

The ability to specify the full name of the join type has been added. This can be useful, for example, for specifying LEFT JOIN LATERAL in PostgreSQL.
