### PR TITLE
fix: add parameter consideration when hashing the query part with orderBy

### DIFF
--- a/src/Driver/CompilerCache.php
+++ b/src/Driver/CompilerCache.php
@@ -193,9 +193,7 @@ final class CompilerCache implements CompilerInterface
 
         $hash .= implode(',', $tokens['groupBy']);
 
-        foreach ($tokens['orderBy'] as $order) {
-            $hash .= $order[0] . $order[1];
-        }
+        $hash .= $this->hashOrderBy($params, $tokens['orderBy']);
 
         $hash .= $this->compiler->hashLimit($params, $tokens);
 
@@ -354,5 +352,20 @@ final class CompilerCache implements CompilerInterface
         $params->push($param);
 
         return '?';
+    }
+
+    private function hashOrderBy(QueryParameters $params, array $tokens): string
+    {
+        $hash = '';
+        foreach ($tokens as $order) {
+            if ($order[0] instanceof FragmentInterface) {
+                foreach ($order[0]->getTokens()['parameters'] as $param) {
+                    $params->push($param);
+                }
+            }
+            $hash .= $order[0] . $order[1];
+        }
+
+        return $hash;
     }
 }

--- a/tests/Database/Functional/Driver/Common/Query/SelectQueryTest.php
+++ b/tests/Database/Functional/Driver/Common/Query/SelectQueryTest.php
@@ -926,6 +926,45 @@ WHERE {name} = \'Antony\' AND {id} IN (SELECT{id}FROM {other}WHERE {x} = 123)',
         );
     }
 
+    public function testOrderByWithExpressionAndParameter(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from('permissions')
+            ->orderBy(new Expression('role = ?', '*'), 'DESC');
+
+        $this->assertSameQuery('SELECT * FROM {permissions} ORDER BY {role} = ? DESC', $select);
+        $this->assertSameParameters(['*'], $select);
+    }
+
+    public function testOrderByWithFragmentAndParameter(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from('permissions')
+            ->orderBy(new Fragment('"role" = ?', '*'), 'DESC');
+
+        $this->assertSameQuery('SELECT * FROM {permissions} ORDER BY "role" = ? DESC', $select);
+        $this->assertSameParameters(['*'], $select);
+    }
+
+    public function testOrderByWithFragmentAndParameterInArray(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from('permissions')
+            ->orderBy([
+                new Fragment('"role" = ? DESC', '*'),
+                'read' => 'ASC',
+            ]);
+
+        $this->assertSameQuery(
+            'SELECT * FROM {permissions} ORDER BY "role" = ? DESC, {read} ASC',
+            $select
+        );
+        $this->assertSameParameters(['*'], $select);
+    }
+
     //Group By
 
     public function testGroupBy(): void

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   mysql_latest:
     image: mysql:latest
     restart: always
-    command: --default-authentication-plugin=mysql_native_password
+    command: --mysql-native-password=ON
     ports:
       - "13306:3306"
     environment:


### PR DESCRIPTION
## 🔍 What was changed

The **orderBy** method can accept a `Cycle\Database\Injection\FragmentInterface`. These can be instances of the `Cycle\Database\Injection\Fragment` and `Cycle\Database\Injection\Expression` classes. They may contain parameters, but these were not considered when hashing this part of the query. I added their consideration, similar to how it is done for the other parts of the query.