### PR TITLE
Fix typecasting of an integer to a boolean in SQLite

### DIFF
--- a/src/Driver/SQLite/Schema/SQLiteColumn.php
+++ b/src/Driver/SQLite/Schema/SQLiteColumn.php
@@ -49,7 +49,7 @@ class SQLiteColumn extends AbstractColumn
         'enum'        => 'enum',
 
         //Logical types
-        'boolean'     => 'integer',
+        'boolean'     => ['type' => 'tinyint', 'size' => 1],
 
         //Integer types (size can always be changed with size method), longInteger has method alias
         //bigInteger
@@ -93,7 +93,7 @@ class SQLiteColumn extends AbstractColumn
     protected array $reverseMapping = [
         'primary'     => [['type' => 'integer', 'primaryKey' => true]],
         'enum'        => ['enum'],
-        'boolean'     => ['boolean'],
+        'boolean'     => ['boolean', ['type' => 'tinyint', 'size' => 1]],
         'integer'     => ['int', 'integer', 'mediumint'],
         'tinyInteger' => ['tinyint'],
         'smallInteger' => ['smallint'],

--- a/tests/Database/Functional/Driver/Common/Schema/BooleanColumnTest.php
+++ b/tests/Database/Functional/Driver/Common/Schema/BooleanColumnTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\Common\Schema;
+
+use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
+
+abstract class BooleanColumnTest extends BaseTest
+{
+    public function testBooleanSchema(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->boolean('column');
+        $schema->save();
+        $this->assertSameAsInDB($schema);
+    }
+
+    public function testBooleanAbstractType(): void
+    {
+        $schema = $this->schema('table');
+
+        $schema->boolean('column');
+        $schema->save();
+
+        $column = $this->fetchSchema($schema)->column('column');
+
+        $this->assertSame('boolean', $column->getAbstractType());
+    }
+}

--- a/tests/Database/Functional/Driver/MySQL/Schema/BooleanColumnTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Schema/BooleanColumnTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\MySQL\Schema;
+
+// phpcs:ignore
+use Cycle\Database\Tests\Functional\Driver\Common\Schema\BooleanColumnTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class BooleanColumnTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/Database/Functional/Driver/Postgres/Schema/BooleanColumnTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Schema/BooleanColumnTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\Postgres\Schema;
+
+// phpcs:ignore
+use Cycle\Database\Tests\Functional\Driver\Common\Schema\BooleanColumnTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+final class BooleanColumnTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/Database/Functional/Driver/SQLServer/Schema/BooleanColumnTest.php
+++ b/tests/Database/Functional/Driver/SQLServer/Schema/BooleanColumnTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\SQLServer\Schema;
+
+// phpcs:ignore
+use Cycle\Database\Tests\Functional\Driver\Common\Schema\BooleanColumnTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class BooleanColumnTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/Database/Functional/Driver/SQLite/Schema/BooleanColumnTest.php
+++ b/tests/Database/Functional/Driver/SQLite/Schema/BooleanColumnTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\SQLite\Schema;
+
+// phpcs:ignore
+use Cycle\Database\Tests\Functional\Driver\Common\Schema\BooleanColumnTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class BooleanColumnTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+}


### PR DESCRIPTION
## 🔍 What was changed

Mapping of the boolean type for SQLite

## 🤔 Why?

Booleans are not cast to booleans but are kept as integers, which causes the following exception in the hydrator: `Cycle\ORM\Exception\MapperException: Can't hydrate an entity because property and value types are incompatible.`