### PR TITLE
Add public clearCache method

### DIFF
--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -111,7 +111,7 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
         return $driver;
     }
 
-    public function cleanCache(): void
+    public function clearCache(): void
     {
         $this->queryCache = [];
     }
@@ -138,7 +138,7 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
     public function getSchemaHandler(): HandlerInterface
     {
         // do not allow to carry prepared statements between schema changes
-        $this->cleanCache();
+        $this->clearCache();
 
         return $this->schemaHandler;
     }
@@ -177,7 +177,7 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
     public function disconnect(): void
     {
         try {
-            $this->cleanCache();
+            $this->clearCache();
             $this->pdo = null;
         } catch (\Throwable $e) {
             // disconnect error

--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -106,11 +106,12 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
 
         $driver = clone $this;
         $driver->useCache = false;
+        $driver->queryCache = [];
 
         return $driver;
     }
 
-    public function clearCache(): void
+    public function cleanCache(): void
     {
         $this->queryCache = [];
     }
@@ -137,7 +138,7 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
     public function getSchemaHandler(): HandlerInterface
     {
         // do not allow to carry prepared statements between schema changes
-        $this->clearCache();
+        $this->cleanCache();
 
         return $this->schemaHandler;
     }
@@ -176,7 +177,7 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
     public function disconnect(): void
     {
         try {
-            $this->clearCache();
+            $this->cleanCache();
             $this->pdo = null;
         } catch (\Throwable $e) {
             // disconnect error

--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -110,6 +110,11 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
         return $driver;
     }
 
+    public function clearCache(): void
+    {
+        $this->queryCache = [];
+    }
+
     /**
      * Get driver source database or file name.
      *
@@ -132,7 +137,7 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
     public function getSchemaHandler(): HandlerInterface
     {
         // do not allow to carry prepared statements between schema changes
-        $this->queryCache = [];
+        $this->clearCache();
 
         return $this->schemaHandler;
     }
@@ -171,7 +176,7 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
     public function disconnect(): void
     {
         try {
-            $this->queryCache = [];
+            $this->clearCache();
             $this->pdo = null;
         } catch (\Throwable $e) {
             // disconnect error

--- a/src/Driver/Jsoner.php
+++ b/src/Driver/Jsoner.php
@@ -32,7 +32,7 @@ final class Jsoner
 
         $result = (string) $value;
 
-        if ($validate && !json_validate($result)) {
+        if ($validate && !\json_validate($result)) {
             throw new BuilderException('Invalid JSON value.');
         }
 

--- a/src/Schema/AbstractColumn.php
+++ b/src/Schema/AbstractColumn.php
@@ -624,6 +624,15 @@ abstract class AbstractColumn implements ColumnInterface, ElementInterface
     }
 
     /**
+     * Get column comment.
+     * An empty string will be returned if the feature is not supported by the driver.
+     */
+    public function getComment(): string
+    {
+        return '';
+    }
+
+    /**
      * Shortcut for AbstractColumn->type() method.
      *
      * @psalm-param non-empty-string $name
@@ -784,14 +793,5 @@ abstract class AbstractColumn implements ColumnInterface, ElementInterface
             'date' => $datetime->format(static::DATE_FORMAT),
             default => $value,
         };
-    }
-
-    /**
-     * Get column comment.
-     * An empty string will be returned if the feature is not supported by the driver.
-     */
-    public function getComment(): string
-    {
-        return '';
     }
 }

--- a/tests/Database/Functional/Driver/Common/Driver/DriverTest.php
+++ b/tests/Database/Functional/Driver/Common/Driver/DriverTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Cycle\Database\Tests\Functional\Driver\Common\Driver;
 
+use Cycle\Database\Config\DriverConfig;
+use Cycle\Database\Driver\Driver;
+use Cycle\Database\Exception\StatementException;
 use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
 
 abstract class DriverTest extends BaseTest
@@ -58,5 +61,63 @@ abstract class DriverTest extends BaseTest
         yield [new \DateTime('2000-01-23T01:23:45.678+09:00')];
         yield [new class('2000-01-23T01:23:45.678+09:00') extends \DateTimeImmutable {}];
         yield [new class('2000-01-23T01:23:45.678+09:00') extends \DateTime {}];
+    }
+
+    public function testCleanCache(): void
+    {
+        $driver = $this->mockDriver();
+
+        $driver->testPolluteCache();
+        self::assertNotEmpty($driver->testGetCache());
+
+        $driver->cleanCache();
+
+        self::assertEmpty($driver->testGetCache());
+    }
+
+    public function testWithoutCache(): void
+    {
+        $driver = $this->mockDriver();
+        $driver->testPolluteCache();
+        self::assertNotEmpty($driver->testGetCache());
+
+        $new = $driver->withoutCache();
+
+        self::assertNotEmpty($driver->testGetCache());
+        self::assertEmpty($new->testGetCache());
+    }
+
+    private function mockDriver(): Driver
+    {
+        return new class extends Driver {
+            public function __construct() {}
+
+            public function testPolluteCache(): void
+            {
+                $this->queryCache[] = ['sql' => 'SELECT * FROM table', 'params' => []];
+            }
+
+            public function testGetCache(): array
+            {
+                return $this->queryCache;
+            }
+
+            protected function mapException(\Throwable $exception, string $query): StatementException
+            {
+                throw new \Exception('not needed');
+            }
+
+            public static function create(DriverConfig $config): \Cycle\Database\Driver\DriverInterface
+            {
+                throw new \Exception('not needed');
+            }
+
+            public function getType(): string
+            {
+                throw new \Exception('not needed');
+            }
+
+            public function __clone(): void {}
+        };
     }
 }

--- a/tests/Database/Functional/Driver/Common/Driver/DriverTest.php
+++ b/tests/Database/Functional/Driver/Common/Driver/DriverTest.php
@@ -63,14 +63,14 @@ abstract class DriverTest extends BaseTest
         yield [new class('2000-01-23T01:23:45.678+09:00') extends \DateTime {}];
     }
 
-    public function testCleanCache(): void
+    public function testClearCache(): void
     {
         $driver = $this->mockDriver();
 
         $driver->testPolluteCache();
         self::assertNotEmpty($driver->testGetCache());
 
-        $driver->cleanCache();
+        $driver->clearCache();
 
         self::assertEmpty($driver->testGetCache());
     }

--- a/tests/Database/Functional/Driver/Common/Schema/CommentTest.php
+++ b/tests/Database/Functional/Driver/Common/Schema/CommentTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Cycle\Database\Tests\Functional\Driver\Common\Schema;
 
 // phpcs:ignore
-use Cycle\Database\ColumnInterface;
 use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
 use Cycle\Database\Tests\Utils\DontGenerateAttribute;
 

--- a/tests/generate.php
+++ b/tests/generate.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 use Cycle\Database\Tests\Utils\DontGenerateAttribute;
 use Spiral\Tokenizer;
 
-error_reporting(E_ALL | E_STRICT);
-ini_set('display_errors', '1');
+\error_reporting(E_ALL | E_STRICT);
+\ini_set('display_errors', '1');
 
 //Composer
-require_once dirname(__DIR__) . '/vendor/autoload.php';
+require_once \dirname(__DIR__) . '/vendor/autoload.php';
 
 $tokenizer = new Tokenizer\Tokenizer(new Tokenizer\Config\TokenizerConfig([
     'directories' => [__DIR__ . '/Database/Functional/Driver/Common'],
@@ -67,7 +67,7 @@ foreach ($classes as $class) {
         \str_replace('\\', '/', $class->getFileName()),
     );
 
-    $path = ltrim($path, '/');
+    $path = \ltrim($path, '/');
 
     foreach ($databases as $driver => $details) {
         $filename = $details['directory'] . $path;


### PR DESCRIPTION
## 🔍 What was changed

Added a dedicated `clearCache()` method to the Driver class and replaced existing direct cache clearing (setting `$this->queryCache = []`) with calls to this method. Also fixed a namespace prefix for the `json_validate()` function.

## 🤔 Why?

These changes improve code maintainability by:
1. Centralizing cache clearing logic into a single method
2. Making cache clearing implementation consistent across the codebase
3. Ensuring proper namespace resolution for PHP functions

## 📝 Checklist

- Closes #<!-- add issue number here if applicable -->
- How was this tested:
  - [x] Tested manually
  - [x] Unit tests added

## 📃 Documentation

No documentation updates needed as this is an internal implementation change that doesn't affect public API.
