### PR TITLE
Update SelectQuery.php

### DIFF
--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -368,7 +368,18 @@ class SelectQuery extends ActiveQuery implements
     {
         return $this->run();
     }
-
+    /**
+     * Request the first result as array (when you know that you have just one result).
+     */
+        public function fetch(int $mode = StatementInterface::FETCH_ASSOC): array
+    {
+        $st = $this->run();
+        try {
+            return $st->fetch($mode);
+        } finally {
+            $st->close();
+        }
+    }
     /**
      * Request all results as array.
      */


### PR DESCRIPTION

## 🔍 What was changed

Adding fetch() simplifies common one-row use cases, makes intent explicit, and avoids the perf overhead of materialising an unused array.
![image](https://github.com/user-attachments/assets/ee2f2bb9-b7b7-423c-aea1-bcb8e25c2375)

## 🤔 Why?

1. Clearer intent
fetch() makes it obvious we expect one record (or null).
Code reviewers no longer have to parse an indexing expression to know this.

2. Avoids unnecessary allocations
fetchAll() builds a PHP array for every row returned by the database driver.
When the caller only needs the first row, we:
allocate and populate an array for all rows,
immediately destroy most of it,
pay the GC cost later.

fetch() stops reading after the first result, closes the cursor in the finally, and releases the driver buffer early. This is a measurable win on large result sets and in tight loops.

3. Reduces boilerplate and error-prone code
No more [0] ?? null, no more manual casts, no more “did we forget to check the array isn’t empty?” bugs. The new method returns:

an array representing the row (default FETCH_ASSOC), or
false when the result set is empty (mirrors PDO).


- How was this tested:
  - [X] Tested manually
  - [ ] Unit tests added


