### PR TITLE
Feature/upsert

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -17,6 +17,7 @@ use Cycle\Database\Query\DeleteQuery;
 use Cycle\Database\Query\InsertQuery;
 use Cycle\Database\Query\SelectQuery;
 use Cycle\Database\Query\UpdateQuery;
+use Cycle\Database\Query\UpsertQuery;
 
 /**
  * Database class is high level abstraction at top of Driver. Databases usually linked to real
@@ -137,6 +138,13 @@ final class Database implements DatabaseInterface
         return $this->getDriver(self::WRITE)
             ->getQueryBuilder()
             ->insertQuery($this->prefix, $table);
+    }
+
+    public function upsert(?string $table = null): UpsertQuery
+    {
+        return $this->getDriver(self::WRITE)
+            ->getQueryBuilder()
+            ->upsertQuery($this->prefix, $table);
     }
 
     public function update(?string $table = null, array $values = [], array $where = []): UpdateQuery

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -17,6 +17,7 @@ use Cycle\Database\Query\DeleteQuery;
 use Cycle\Database\Query\InsertQuery;
 use Cycle\Database\Query\SelectQuery;
 use Cycle\Database\Query\UpdateQuery;
+use Cycle\Database\Query\UpsertQuery;
 
 /**
  * DatabaseInterface is high level abstraction used to represent single database. You must always
@@ -103,6 +104,15 @@ interface DatabaseInterface
      * @see self::withoutCache() May be useful to disable query cache for batch inserts.
      */
     public function insert(string $table = ''): InsertQuery;
+
+    /**
+     * Get instance of UpsertBuilder associated with current Database.
+     *
+     * @param string $table Table where values should be upserted to.
+     *
+     * @see self::withoutCache() May be useful to disable query cache for batch inserts.
+     */
+    public function upsert(string $table = ''): UpsertQuery;
 
     /**
      * Get instance of UpdateBuilder associated with current Database.

--- a/src/Driver/Compiler.php
+++ b/src/Driver/Compiler.php
@@ -188,34 +188,22 @@ abstract class Compiler implements CompilerInterface
             $values[] = $this->value($params, $q, $value);
         }
 
+        $updates = \array_map(
+            function (string $column) use ($params, $q) {
+                $name   = $this->name($params, $q, $column);
+                return \sprintf('%s = EXCLUDED.%s', $name, $name);
+            },
+            $tokens['columns'],
+        );
+
         return \sprintf(
-            'INSERT INTO %s (%s) VALUES %s AS %s ON CONFLICT (%s) DO UPDATE SET %s',
+            'INSERT INTO %s (%s) VALUES %s ON CONFLICT (%s) DO UPDATE SET %s',
             $this->name($params, $q, $tokens['table'], true),
             $this->columns($params, $q, $tokens['columns']),
             \implode(', ', $values),
-            $this->name($params, $q, $tokens['target']),
             $this->columns($params, $q, $tokens['conflicts']),
-            $this->updates($params, $q, $tokens['columns'], $tokens['target']),
+            \implode(', ', $updates),
         );
-    }
-
-    protected function updates(
-        QueryParameters $params,
-        Quoter $q,
-        array $columns,
-        string $target,
-        int $maxLength = 180,
-    ): string {
-        $columns = \array_map(
-            function ($column) use ($params, $q, $target) {
-                $name   = $this->name($params, $q, $column);
-                $target = $this->name($params, $q, $target);
-                return \sprintf('%s = %s.%s', $name, $target, $name);
-            },
-            $columns,
-        );
-
-        return \wordwrap(\implode(', ', $columns), $maxLength);
     }
 
     /**

--- a/src/Driver/Compiler.php
+++ b/src/Driver/Compiler.php
@@ -109,6 +109,9 @@ abstract class Compiler implements CompilerInterface
             case self::INSERT_QUERY:
                 return $this->insertQuery($params, $q, $tokens);
 
+            case self::UPSERT_QUERY:
+                return $this->upsertQuery($params, $q, $tokens);
+
             case self::SELECT_QUERY:
                 if ($nestedQuery) {
                     if ($fragment->getPrefix() !== null) {
@@ -164,6 +167,51 @@ abstract class Compiler implements CompilerInterface
             $this->columns($params, $q, $tokens['columns']),
             \implode(', ', $values),
         );
+    }
+
+    /**
+     * @psalm-return non-empty-string
+     */
+    protected function upsertQuery(QueryParameters $params, Quoter $q, array $tokens): string
+    {
+        if (\count($tokens['columns']) === 0) {
+            throw new CompilerException('Upsert query must define at least one column');
+        }
+
+        $values = [];
+        foreach ($tokens['values'] as $value) {
+            $values[] = $this->value($params, $q, $value);
+        }
+
+        $alias = $tokens['alias'] ?? \uniqid();
+
+        return \sprintf(
+            'INSERT INTO %s (%s) VALUES %s AS %s ON DUPLICATE KEY UPDATE %s',
+            $this->name($params, $q, $tokens['table'], true),
+            $this->columns($params, $q, $tokens['columns']),
+            \implode(', ', $values),
+            $this->name($params, $q, $alias),
+            $this->updates($params, $q, $tokens['columns'], $alias),
+        );
+    }
+
+    protected function updates(
+        QueryParameters $params,
+        Quoter $q,
+        array $columns,
+        ?string $alias = null,
+        int $maxLength = 180,
+    ): string {
+        $columns = \array_map(
+            function ($column) use ($params, $q, $alias) {
+                $name = $this->name($params, $q, $column);
+                $alias = $this->name($params, $q, $alias);
+                return \sprintf('%s = %s.%s', $name, $alias, $name);
+            },
+            $columns,
+        );
+
+        return \wordwrap(\implode(', ', $columns), $maxLength);
     }
 
     /**

--- a/src/Driver/Compiler.php
+++ b/src/Driver/Compiler.php
@@ -174,24 +174,28 @@ abstract class Compiler implements CompilerInterface
      */
     protected function upsertQuery(QueryParameters $params, Quoter $q, array $tokens): string
     {
+        if (\count($tokens['conflicts']) === 0) {
+            throw new CompilerException('Upsert query must define conflicting index column names');
+        }
+
         if (\count($tokens['columns']) === 0) {
             throw new CompilerException('Upsert query must define at least one column');
         }
 
         $values = [];
+
         foreach ($tokens['values'] as $value) {
             $values[] = $this->value($params, $q, $value);
         }
 
-        $alias = $tokens['alias'] ?? \uniqid();
-
         return \sprintf(
-            'INSERT INTO %s (%s) VALUES %s AS %s ON DUPLICATE KEY UPDATE %s',
+            'INSERT INTO %s (%s) VALUES %s AS %s ON CONFLICT (%s) DO UPDATE SET %s',
             $this->name($params, $q, $tokens['table'], true),
             $this->columns($params, $q, $tokens['columns']),
             \implode(', ', $values),
-            $this->name($params, $q, $alias),
-            $this->updates($params, $q, $tokens['columns'], $alias),
+            $this->name($params, $q, $tokens['target']),
+            $this->columns($params, $q, $tokens['conflicts']),
+            $this->updates($params, $q, $tokens['columns'], $tokens['target']),
         );
     }
 
@@ -199,14 +203,14 @@ abstract class Compiler implements CompilerInterface
         QueryParameters $params,
         Quoter $q,
         array $columns,
-        ?string $alias = null,
+        string $target,
         int $maxLength = 180,
     ): string {
         $columns = \array_map(
-            function ($column) use ($params, $q, $alias) {
-                $name = $this->name($params, $q, $column);
-                $alias = $this->name($params, $q, $alias);
-                return \sprintf('%s = %s.%s', $name, $alias, $name);
+            function ($column) use ($params, $q, $target) {
+                $name   = $this->name($params, $q, $column);
+                $target = $this->name($params, $q, $target);
+                return \sprintf('%s = %s.%s', $name, $target, $name);
             },
             $columns,
         );

--- a/src/Driver/CompilerInterface.php
+++ b/src/Driver/CompilerInterface.php
@@ -24,6 +24,7 @@ interface CompilerInterface
     public const UPDATE_QUERY = 6;
     public const DELETE_QUERY = 7;
     public const JSON_EXPRESSION = 8;
+    public const UPSERT_QUERY = 9;
     public const TOKEN_AND = '@AND';
     public const TOKEN_OR = '@OR';
     public const TOKEN_AND_NOT = '@AND NOT';

--- a/src/Driver/MySQL/MySQLCompiler.php
+++ b/src/Driver/MySQL/MySQLCompiler.php
@@ -52,13 +52,20 @@ class MySQLCompiler extends Compiler implements CachingCompilerInterface
             $values[] = $this->value($params, $q, $value);
         }
 
+        $updates = \array_map(
+            function ($column) use ($params, $q) {
+                $name   = $this->name($params, $q, $column);
+                return \sprintf('%s = VALUES(%s)', $name, $name);
+            },
+            $tokens['columns'],
+        );
+
         return \sprintf(
-            'INSERT INTO %s (%s) VALUES %s AS %s ON DUPLICATE KEY UPDATE %s',
+            'INSERT INTO %s (%s) VALUES %s ON DUPLICATE KEY UPDATE %s',
             $this->name($params, $q, $tokens['table'], true),
             $this->columns($params, $q, $tokens['columns']),
             \implode(', ', $values),
-            $this->name($params, $q, $tokens['target']),
-            $this->updates($params, $q, $tokens['columns'], $tokens['target']),
+            \implode(', ', $updates),
         );
     }
 

--- a/src/Driver/MySQL/MySQLCompiler.php
+++ b/src/Driver/MySQL/MySQLCompiler.php
@@ -15,6 +15,7 @@ use Cycle\Database\Driver\CachingCompilerInterface;
 use Cycle\Database\Driver\Compiler;
 use Cycle\Database\Driver\MySQL\Injection\CompileJson;
 use Cycle\Database\Driver\Quoter;
+use Cycle\Database\Exception\CompilerException;
 use Cycle\Database\Injection\FragmentInterface;
 use Cycle\Database\Injection\Parameter;
 use Cycle\Database\Query\QueryParameters;
@@ -34,6 +35,31 @@ class MySQLCompiler extends Compiler implements CachingCompilerInterface
         }
 
         return parent::insertQuery($params, $q, $tokens);
+    }
+
+    /**
+     * @psalm-return non-empty-string
+     */
+    protected function upsertQuery(QueryParameters $params, Quoter $q, array $tokens): string
+    {
+        if (\count($tokens['columns']) === 0) {
+            throw new CompilerException('Upsert query must define at least one column');
+        }
+
+        $values = [];
+
+        foreach ($tokens['values'] as $value) {
+            $values[] = $this->value($params, $q, $value);
+        }
+
+        return \sprintf(
+            'INSERT INTO %s (%s) VALUES %s AS %s ON DUPLICATE KEY UPDATE %s',
+            $this->name($params, $q, $tokens['table'], true),
+            $this->columns($params, $q, $tokens['columns']),
+            \implode(', ', $values),
+            $this->name($params, $q, $tokens['target']),
+            $this->updates($params, $q, $tokens['columns'], $tokens['target']),
+        );
     }
 
     /**

--- a/src/Driver/MySQL/MySQLDriver.php
+++ b/src/Driver/MySQL/MySQLDriver.php
@@ -20,6 +20,7 @@ use Cycle\Database\Driver\MySQL\Query\MySQLUpdateQuery;
 use Cycle\Database\Exception\StatementException;
 use Cycle\Database\Query\InsertQuery;
 use Cycle\Database\Query\QueryBuilder;
+use Cycle\Database\Query\UpsertQuery;
 
 /**
  * Talks to mysql databases.
@@ -38,6 +39,7 @@ class MySQLDriver extends Driver
             new QueryBuilder(
                 new MySQLSelectQuery(),
                 new InsertQuery(),
+                new UpsertQuery(),
                 new MySQLUpdateQuery(),
                 new MySQLDeleteQuery(),
             ),

--- a/src/Driver/Postgres/PostgresCompiler.php
+++ b/src/Driver/Postgres/PostgresCompiler.php
@@ -15,7 +15,6 @@ use Cycle\Database\Driver\CachingCompilerInterface;
 use Cycle\Database\Driver\Compiler;
 use Cycle\Database\Driver\Postgres\Injection\CompileJson;
 use Cycle\Database\Driver\Quoter;
-use Cycle\Database\Exception\CompilerException;
 use Cycle\Database\Injection\FragmentInterface;
 use Cycle\Database\Injection\Parameter;
 use Cycle\Database\Query\QueryParameters;
@@ -58,25 +57,7 @@ class PostgresCompiler extends Compiler implements CachingCompilerInterface
      */
     protected function upsertQuery(QueryParameters $params, Quoter $q, array $tokens): string
     {
-        if (\count($tokens['columns']) === 0) {
-            throw new CompilerException('Upsert query must define at least one column');
-        }
-
-        $values = [];
-        foreach ($tokens['values'] as $value) {
-            $values[] = $this->value($params, $q, $value);
-        }
-
-        $alias = $tokens['alias'] ?? \uniqid();
-
-        $query = \sprintf(
-            'INSERT INTO %s (%s) VALUES %s AS %s ON CONFLICT DO UPDATE SET %s',
-            $this->name($params, $q, $tokens['table'], true),
-            $this->columns($params, $q, $tokens['columns']),
-            \implode(', ', $values),
-            $this->name($params, $q, $alias),
-            $this->updates($params, $q, $tokens['columns'], $alias),
-        );
+        $query = parent::upsertQuery($params, $q, $tokens);
 
         if (empty($tokens['return'])) {
             return $query;

--- a/src/Driver/Postgres/PostgresCompiler.php
+++ b/src/Driver/Postgres/PostgresCompiler.php
@@ -15,6 +15,7 @@ use Cycle\Database\Driver\CachingCompilerInterface;
 use Cycle\Database\Driver\Compiler;
 use Cycle\Database\Driver\Postgres\Injection\CompileJson;
 use Cycle\Database\Driver\Quoter;
+use Cycle\Database\Exception\CompilerException;
 use Cycle\Database\Injection\FragmentInterface;
 use Cycle\Database\Injection\Parameter;
 use Cycle\Database\Query\QueryParameters;
@@ -43,6 +44,47 @@ class PostgresCompiler extends Compiler implements CachingCompilerInterface
         return \sprintf(
             '%s RETURNING %s',
             $result,
+            \implode(',', \array_map(
+                fn(string|FragmentInterface|null $return) => $return instanceof FragmentInterface
+                    ? $this->fragment($params, $q, $return)
+                    : $this->quoteIdentifier($return),
+                $tokens['return'],
+            )),
+        );
+    }
+
+    /**
+     * @psalm-return non-empty-string
+     */
+    protected function upsertQuery(QueryParameters $params, Quoter $q, array $tokens): string
+    {
+        if (\count($tokens['columns']) === 0) {
+            throw new CompilerException('Upsert query must define at least one column');
+        }
+
+        $values = [];
+        foreach ($tokens['values'] as $value) {
+            $values[] = $this->value($params, $q, $value);
+        }
+
+        $alias = $tokens['alias'] ?? \uniqid();
+
+        $query = \sprintf(
+            'INSERT INTO %s (%s) VALUES %s AS %s ON CONFLICT DO UPDATE SET %s',
+            $this->name($params, $q, $tokens['table'], true),
+            $this->columns($params, $q, $tokens['columns']),
+            \implode(', ', $values),
+            $this->name($params, $q, $alias),
+            $this->updates($params, $q, $tokens['columns'], $alias),
+        );
+
+        if (empty($tokens['return'])) {
+            return $query;
+        }
+
+        return \sprintf(
+            '%s RETURNING %s',
+            $query,
             \implode(',', \array_map(
                 fn(string|FragmentInterface|null $return) => $return instanceof FragmentInterface
                     ? $this->fragment($params, $q, $return)

--- a/src/Driver/Postgres/PostgresDriver.php
+++ b/src/Driver/Postgres/PostgresDriver.php
@@ -19,6 +19,7 @@ use Cycle\Database\Driver\Postgres\Query\PostgresDeleteQuery;
 use Cycle\Database\Driver\Postgres\Query\PostgresInsertQuery;
 use Cycle\Database\Driver\Postgres\Query\PostgresSelectQuery;
 use Cycle\Database\Driver\Postgres\Query\PostgresUpdateQuery;
+use Cycle\Database\Driver\Postgres\Query\PostgresUpsertQuery;
 use Cycle\Database\Exception\DriverException;
 use Cycle\Database\Exception\StatementException;
 use Cycle\Database\Query\QueryBuilder;
@@ -65,6 +66,7 @@ class PostgresDriver extends Driver
             new QueryBuilder(
                 new PostgresSelectQuery(),
                 new PostgresInsertQuery(),
+                new PostgresUpsertQuery(),
                 new PostgresUpdateQuery(),
                 new PostgresDeleteQuery(),
             ),

--- a/src/Driver/Postgres/Query/PostgresUpsertQuery.php
+++ b/src/Driver/Postgres/Query/PostgresUpsertQuery.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * This file is part of Cycle ORM package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Driver\Postgres\Query;
+
+use Cycle\Database\Driver\DriverInterface;
+use Cycle\Database\Driver\Postgres\PostgresDriver;
+use Cycle\Database\Exception\BuilderException;
+use Cycle\Database\Exception\ReadonlyConnectionException;
+use Cycle\Database\Injection\FragmentInterface;
+use Cycle\Database\Query\ReturningInterface;
+use Cycle\Database\Query\QueryInterface;
+use Cycle\Database\Query\QueryParameters;
+use Cycle\Database\Query\UpsertQuery;
+use Cycle\Database\StatementInterface;
+
+/**
+ * Postgres driver requires a slightly different way to handle last insert id.
+ */
+class PostgresUpsertQuery extends UpsertQuery implements ReturningInterface
+{
+    /** @var PostgresDriver|null */
+    protected ?DriverInterface $driver = null;
+
+    /** @deprecated */
+    protected string|FragmentInterface|null $returning = null;
+
+    /** @var list<FragmentInterface|non-empty-string> */
+    protected array $returningColumns = [];
+
+    public function withDriver(DriverInterface $driver, ?string $prefix = null): QueryInterface
+    {
+        $driver instanceof PostgresDriver or throw new BuilderException(
+            'Postgres UpsertQuery can be used only with Postgres driver',
+        );
+
+        return parent::withDriver($driver, $prefix);
+    }
+
+    /**
+     * Set returning column. If not set, the driver will detect PK automatically.
+     */
+    public function returning(string|FragmentInterface ...$columns): self
+    {
+        $columns === [] and throw new BuilderException('RETURNING clause should contain at least 1 column.');
+
+        $this->returning = \count($columns) === 1 ? \reset($columns) : null;
+
+        $this->returningColumns = \array_values($columns);
+
+        return $this;
+    }
+
+    public function run(): mixed
+    {
+        $params = new QueryParameters();
+        $queryString = $this->sqlStatement($params);
+
+        $this->driver->isReadonly() and throw ReadonlyConnectionException::onWriteStatementExecution();
+
+        $result = $this->driver->query($queryString, $params->getParameters());
+
+        try {
+            if ($this->returningColumns !== []) {
+                if (\count($this->returningColumns) === 1) {
+                    return $result->fetchColumn();
+                }
+
+                return $result->fetch(StatementInterface::FETCH_ASSOC);
+            }
+
+            // Return PK if no RETURNING clause is set
+            if ($this->getPrimaryKey() !== null) {
+                return $result->fetchColumn();
+            }
+
+            return null;
+        } finally {
+            $result->close();
+        }
+    }
+
+    public function getTokens(): array
+    {
+        return parent::getTokens() + [
+            'return'  => $this->returningColumns !== [] ? $this->returningColumns : (array) $this->getPrimaryKey(),
+        ];
+    }
+
+    private function getPrimaryKey(): ?string
+    {
+        try {
+            return $this->driver?->getPrimaryKey($this->prefix, $this->table);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/src/Driver/SQLServer/Query/SQLServerUpsertQuery.php
+++ b/src/Driver/SQLServer/Query/SQLServerUpsertQuery.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of Cycle ORM package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Driver\SQLServer\Query;
+
+use Cycle\Database\Driver\DriverInterface;
+use Cycle\Database\Driver\SQLServer\SQLServerDriver;
+use Cycle\Database\Exception\BuilderException;
+use Cycle\Database\Exception\ReadonlyConnectionException;
+use Cycle\Database\Injection\FragmentInterface;
+use Cycle\Database\Query\QueryParameters;
+use Cycle\Database\Query\ReturningInterface;
+use Cycle\Database\Query\UpsertQuery;
+use Cycle\Database\Query\QueryInterface;
+use Cycle\Database\StatementInterface;
+
+class SQLServerUpsertQuery extends UpsertQuery implements ReturningInterface
+{
+    /**
+     * @var SQLServerDriver|null
+     */
+    protected ?DriverInterface $driver = null;
+
+    /**
+     * @var list<FragmentInterface|non-empty-string>
+     */
+    protected array $returningColumns = [];
+
+    public function withDriver(DriverInterface $driver, ?string $prefix = null): QueryInterface
+    {
+        $driver instanceof SQLServerDriver or throw new BuilderException(
+            'SQLServer UpsertQuery can be used only with SQLServer driver',
+        );
+
+        return parent::withDriver($driver, $prefix);
+    }
+
+    public function returning(string|FragmentInterface ...$columns): self
+    {
+        $columns === [] and throw new BuilderException('RETURNING clause should contain at least 1 column.');
+
+        $this->returningColumns = \array_values($columns);
+
+        return $this;
+    }
+
+    public function run(): mixed
+    {
+        if ($this->returningColumns === []) {
+            return parent::run();
+        }
+
+        $params = new QueryParameters();
+        $queryString = $this->sqlStatement($params);
+
+        $this->driver->isReadonly() and throw ReadonlyConnectionException::onWriteStatementExecution();
+
+        $result = $this->driver->query($queryString, $params->getParameters());
+
+        try {
+            if (\count($this->returningColumns) === 1) {
+                return $result->fetchColumn();
+            }
+            return $result->fetch(StatementInterface::FETCH_ASSOC);
+        } finally {
+            $result->close();
+        }
+    }
+
+    public function getTokens(): array
+    {
+        return parent::getTokens() + [
+            'return' => $this->returningColumns,
+        ];
+    }
+}

--- a/src/Driver/SQLServer/SQLServerCompiler.php
+++ b/src/Driver/SQLServer/SQLServerCompiler.php
@@ -69,9 +69,87 @@ class SQLServerCompiler extends Compiler
         );
     }
 
+    /**
+     * @psalm-return non-empty-string
+     */
     protected function upsertQuery(QueryParameters $params, Quoter $q, array $tokens): string
     {
-        throw new CompilerException('Upsert behaviour is not supported by SQLServer');
+        if (\count($tokens['conflicts']) === 0) {
+            throw new CompilerException('Upsert query must define conflicting index column names');
+        }
+
+        if (\count($tokens['columns']) === 0) {
+            throw new CompilerException('Upsert query must define at least one column');
+        }
+
+        $values = [];
+
+        foreach ($tokens['values'] as $value) {
+            $values[] = $this->value($params, $q, $value);
+        }
+
+        $target = $tokens['target'];
+        $source = $tokens['source'];
+
+        $conflicts = \array_map(
+            function ($column) use ($params, $q, $target, $source) {
+                $name = $this->name($params, $q, $column);
+                $target = $this->name($params, $q, $target);
+                $source = $this->name($params, $q, $source);
+                return \sprintf('%s.%s = %s.%s', $target, $name, $source, $name);
+            },
+            $tokens['conflicts'],
+        );
+
+        $matched = \array_map(
+            function ($column) use ($params, $q, $target, $source) {
+                $name = $this->name($params, $q, $column);
+                $target = $this->name($params, $q, $target);
+                $source = $this->name($params, $q, $source);
+                return \sprintf('%s.%s = %s.%s', $target, $name, $source, $name);
+            },
+            $tokens['columns'],
+        );
+
+        $sources = \array_map(
+            function ($column) use ($params, $q, $source) {
+                $name = $this->name($params, $q, $column);
+                $source = $this->name($params, $q, $source);
+                return \sprintf('%s.%s', $source, $name);
+            },
+            $tokens['columns'],
+        );
+
+        //MERGE INTO users WITH (holdlock) AS target
+        //USING (
+        //    VALUES
+        //        ('adam@email.com', 'Adam')),
+        //        ('mark@email.com', 'Mark')
+        //) AS source (name, email, created_at)
+        //ON target.email = source.email  -- assuming email has a unique constraint
+        //WHEN MATCHED THEN
+        //    UPDATE SET
+        //        target.name = source.name,
+        //        target.email = source.email,
+        //        target.created_at = source.created_at
+        //WHEN NOT MATCHED THEN
+        //    INSERT (name, email, created_at)
+        //    VALUES (source.name, source.email, source.created_at);
+        //
+        //MERGEINTO[table]WITH(holdlock)AS[target]USING(VALUES(?,?))AS[source]([email],[name])ON[target].[email]=[source].[email]WHENMATCHEDTHENUPDATESET[target].[email]=[source].[email],[target].[name]=[source].[name]WHENNOTMATCHEDTHENINSERT([email],[name])VALUES([source].[email],[source].[name])
+
+        return \sprintf(
+            'MERGE INTO %s WITH (holdlock) AS %s USING ( VALUES %s) AS %s (%s) ON %s WHEN MATCHED THEN UPDATE SET %s WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s)',
+            $this->name($params, $q, $tokens['table'], true),
+            $this->name($params, $q, $target),
+            \implode(', ', $values),
+            $this->name($params, $q, 'source'),
+            $this->columns($params, $q, $tokens['columns']),
+            \implode(' AND ', $conflicts),
+            \implode(', ', $matched),
+            $this->columns($params, $q, $tokens['columns']),
+            \implode(', ', $sources),
+        );
     }
 
     /**

--- a/src/Driver/SQLServer/SQLServerCompiler.php
+++ b/src/Driver/SQLServer/SQLServerCompiler.php
@@ -14,6 +14,7 @@ namespace Cycle\Database\Driver\SQLServer;
 use Cycle\Database\Driver\Compiler;
 use Cycle\Database\Driver\Quoter;
 use Cycle\Database\Driver\SQLServer\Injection\CompileJson;
+use Cycle\Database\Exception\CompilerException;
 use Cycle\Database\Injection\Fragment;
 use Cycle\Database\Injection\FragmentInterface;
 use Cycle\Database\Injection\Parameter;
@@ -66,6 +67,11 @@ class SQLServerCompiler extends Compiler
             $output,
             \implode(', ', $values),
         );
+    }
+
+    protected function upsertQuery(QueryParameters $params, Quoter $q, array $tokens): string
+    {
+        throw new CompilerException('Upsert behaviour is not supported by SQLServer');
     }
 
     /**

--- a/src/Driver/SQLServer/SQLServerCompiler.php
+++ b/src/Driver/SQLServer/SQLServerCompiler.php
@@ -88,11 +88,11 @@ class SQLServerCompiler extends Compiler
             $values[] = $this->value($params, $q, $value);
         }
 
-        $target = $tokens['target'];
-        $source = $tokens['source'];
+        $target = 'target';
+        $source = 'source';
 
         $conflicts = \array_map(
-            function ($column) use ($params, $q, $target, $source) {
+            function (string $column) use ($params, $q, $target, $source) {
                 $name = $this->name($params, $q, $column);
                 $target = $this->name($params, $q, $target);
                 $source = $this->name($params, $q, $source);
@@ -101,8 +101,8 @@ class SQLServerCompiler extends Compiler
             $tokens['conflicts'],
         );
 
-        $matched = \array_map(
-            function ($column) use ($params, $q, $target, $source) {
+        $updates = \array_map(
+            function (string $column) use ($params, $q, $target, $source) {
                 $name = $this->name($params, $q, $column);
                 $target = $this->name($params, $q, $target);
                 $source = $this->name($params, $q, $source);
@@ -111,32 +111,14 @@ class SQLServerCompiler extends Compiler
             $tokens['columns'],
         );
 
-        $sources = \array_map(
-            function ($column) use ($params, $q, $source) {
+        $inserts = \array_map(
+            function (string $column) use ($params, $q, $source) {
                 $name = $this->name($params, $q, $column);
                 $source = $this->name($params, $q, $source);
                 return \sprintf('%s.%s', $source, $name);
             },
             $tokens['columns'],
         );
-
-        //MERGE INTO users WITH (holdlock) AS target
-        //USING (
-        //    VALUES
-        //        ('adam@email.com', 'Adam')),
-        //        ('mark@email.com', 'Mark')
-        //) AS source (name, email, created_at)
-        //ON target.email = source.email  -- assuming email has a unique constraint
-        //WHEN MATCHED THEN
-        //    UPDATE SET
-        //        target.name = source.name,
-        //        target.email = source.email,
-        //        target.created_at = source.created_at
-        //WHEN NOT MATCHED THEN
-        //    INSERT (name, email, created_at)
-        //    VALUES (source.name, source.email, source.created_at);
-        //
-        //MERGEINTO[table]WITH(holdlock)AS[target]USING(VALUES(?,?))AS[source]([email],[name])ON[target].[email]=[source].[email]WHENMATCHEDTHENUPDATESET[target].[email]=[source].[email],[target].[name]=[source].[name]WHENNOTMATCHEDTHENINSERT([email],[name])VALUES([source].[email],[source].[name])
 
         return \sprintf(
             'MERGE INTO %s WITH (holdlock) AS %s USING ( VALUES %s) AS %s (%s) ON %s WHEN MATCHED THEN UPDATE SET %s WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s)',
@@ -146,9 +128,9 @@ class SQLServerCompiler extends Compiler
             $this->name($params, $q, 'source'),
             $this->columns($params, $q, $tokens['columns']),
             \implode(' AND ', $conflicts),
-            \implode(', ', $matched),
+            \implode(', ', $updates),
             $this->columns($params, $q, $tokens['columns']),
-            \implode(', ', $sources),
+            \implode(', ', $inserts),
         );
     }
 

--- a/src/Driver/SQLServer/SQLServerDriver.php
+++ b/src/Driver/SQLServer/SQLServerDriver.php
@@ -19,6 +19,7 @@ use Cycle\Database\Driver\SQLServer\Query\SQLServerDeleteQuery;
 use Cycle\Database\Driver\SQLServer\Query\SQLServerInsertQuery;
 use Cycle\Database\Driver\SQLServer\Query\SQLServerSelectQuery;
 use Cycle\Database\Driver\SQLServer\Query\SQLServerUpdateQuery;
+use Cycle\Database\Driver\SQLServer\Query\SQLServerUpsertQuery;
 use Cycle\Database\Exception\DriverException;
 use Cycle\Database\Exception\StatementException;
 use Cycle\Database\Injection\ParameterInterface;
@@ -45,6 +46,7 @@ class SQLServerDriver extends Driver
             new QueryBuilder(
                 new SQLServerSelectQuery(),
                 new SQLServerInsertQuery(),
+                new SQLServerUpsertQuery(),
                 new SQLServerUpdateQuery(),
                 new SQLServerDeleteQuery(),
             ),

--- a/src/Driver/SQLite/SQLiteCompiler.php
+++ b/src/Driver/SQLite/SQLiteCompiler.php
@@ -121,32 +121,6 @@ class SQLiteCompiler extends Compiler implements CachingCompilerInterface
         return \implode("\n", $statement);
     }
 
-    /**
-     * @psalm-return non-empty-string
-     */
-    protected function upsertQuery(QueryParameters $params, Quoter $q, array $tokens): string
-    {
-        if (\count($tokens['columns']) === 0) {
-            throw new CompilerException('Upsert query must define at least one column');
-        }
-
-        $values = [];
-        foreach ($tokens['values'] as $value) {
-            $values[] = $this->value($params, $q, $value);
-        }
-
-        $alias = $tokens['alias'] ?? \uniqid();
-
-        return \sprintf(
-            'INSERT INTO %s (%s) VALUES %s AS %s ON CONFLICT DO UPDATE SET %s',
-            $this->name($params, $q, $tokens['table'], true),
-            $this->columns($params, $q, $tokens['columns']),
-            \implode(', ', $values),
-            $this->name($params, $q, $alias),
-            $this->updates($params, $q, $tokens['columns'], $alias),
-        );
-    }
-
     protected function compileJsonOrderBy(string $path): FragmentInterface
     {
         return new CompileJson($path);

--- a/src/Driver/SQLite/SQLiteCompiler.php
+++ b/src/Driver/SQLite/SQLiteCompiler.php
@@ -121,6 +121,32 @@ class SQLiteCompiler extends Compiler implements CachingCompilerInterface
         return \implode("\n", $statement);
     }
 
+    /**
+     * @psalm-return non-empty-string
+     */
+    protected function upsertQuery(QueryParameters $params, Quoter $q, array $tokens): string
+    {
+        if (\count($tokens['columns']) === 0) {
+            throw new CompilerException('Upsert query must define at least one column');
+        }
+
+        $values = [];
+        foreach ($tokens['values'] as $value) {
+            $values[] = $this->value($params, $q, $value);
+        }
+
+        $alias = $tokens['alias'] ?? \uniqid();
+
+        return \sprintf(
+            'INSERT INTO %s (%s) VALUES %s AS %s ON CONFLICT DO UPDATE SET %s',
+            $this->name($params, $q, $tokens['table'], true),
+            $this->columns($params, $q, $tokens['columns']),
+            \implode(', ', $values),
+            $this->name($params, $q, $alias),
+            $this->updates($params, $q, $tokens['columns'], $alias),
+        );
+    }
+
     protected function compileJsonOrderBy(string $path): FragmentInterface
     {
         return new CompileJson($path);

--- a/src/Driver/SQLite/SQLiteDriver.php
+++ b/src/Driver/SQLite/SQLiteDriver.php
@@ -20,6 +20,7 @@ use Cycle\Database\Driver\SQLite\Query\SQLiteUpdateQuery;
 use Cycle\Database\Exception\StatementException;
 use Cycle\Database\Query\InsertQuery;
 use Cycle\Database\Query\QueryBuilder;
+use Cycle\Database\Query\UpsertQuery;
 
 class SQLiteDriver extends Driver
 {
@@ -35,6 +36,7 @@ class SQLiteDriver extends Driver
             new QueryBuilder(
                 new SQLiteSelectQuery(),
                 new InsertQuery(),
+                new UpsertQuery(),
                 new SQLiteUpdateQuery(),
                 new SQLiteDeleteQuery(),
             ),

--- a/src/Query/BuilderInterface.php
+++ b/src/Query/BuilderInterface.php
@@ -34,6 +34,15 @@ interface BuilderInterface
     ): InsertQuery;
 
     /**
+     * Get UpsertQuery builder with driver specific query compiler.
+     *
+     */
+    public function upsertQuery(
+        string $prefix,
+        ?string $table = null,
+    ): UpsertQuery;
+
+    /**
      * Get SelectQuery builder with driver specific query compiler.
      *
      */

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -23,6 +23,7 @@ final class QueryBuilder implements BuilderInterface
     public function __construct(
         private SelectQuery $selectQuery,
         private InsertQuery $insertQuery,
+        private UpsertQuery $upsertQuery,
         private UpdateQuery $updateQuery,
         private DeleteQuery $deleteQuery,
     ) {}
@@ -32,6 +33,7 @@ final class QueryBuilder implements BuilderInterface
         return new self(
             new SelectQuery(),
             new InsertQuery(),
+            new UpsertQuery(),
             new UpdateQuery(),
             new DeleteQuery(),
         );
@@ -59,6 +61,22 @@ final class QueryBuilder implements BuilderInterface
         }
 
         return $insert;
+    }
+
+    /**
+     * Get UpsertQuery builder with driver specific query compiler.
+     */
+    public function upsertQuery(
+        string $prefix,
+        ?string $table = null,
+    ): UpsertQuery {
+        $upsert = $this->upsertQuery->withDriver($this->driver, $prefix);
+
+        if ($table !== null) {
+            $upsert->into($table);
+        }
+
+        return $upsert;
     }
 
     /**

--- a/src/Query/UpsertQuery.php
+++ b/src/Query/UpsertQuery.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Query;
+
+use Cycle\Database\Driver\CompilerInterface;
+use Cycle\Database\Injection\Parameter;
+
+class UpsertQuery extends ActiveQuery
+{
+    protected string $table;
+    protected array $columns = [];
+    protected array $values  = [];
+    protected ?string $alias = null;
+
+    public function __construct(?string $table = null)
+    {
+        $this->table = $table ?? '';
+    }
+
+    /**
+     * Set upsert target table.
+     *
+     * @psalm-param non-empty-string $into
+     */
+    public function into(string $into): self
+    {
+        $this->table = $into;
+
+        return $this;
+    }
+
+    /**
+     * Set upsert column names. Names can be provided as array, set of parameters or comma
+     * separated string.
+     *
+     * Examples:
+     * $upsert->columns(["name", "email"]);
+     * $upsert->columns("name", "email");
+     * $upsert->columns("name, email");
+     */
+    public function columns(array|string ...$columns): self
+    {
+        $this->columns = $this->fetchIdentifiers($columns);
+
+        return $this;
+    }
+
+    /**
+     * Set upsert rowset values or multiple rowsets. Values can be provided in multiple forms
+     * (method parameters, array of values, array of rowsets). Columns names will be automatically
+     * fetched (if not already specified) from first provided rowset based on rowset keys.
+     *
+     * Examples:
+     * $upsert->columns("name", "balance")->values("Wolfy-J", 10);
+     * $upsert->values([
+     *      "name" => "Wolfy-J",
+     *      "balance" => 10
+     * ]);
+     * $upsert->values([
+     *  [
+     *      "name" => "Wolfy-J",
+     *      "balance" => 10
+     *  ],
+     *  [
+     *      "name" => "Ben",
+     *      "balance" => 20
+     *  ]
+     * ]);
+     */
+    public function values(mixed $rowsets): self
+    {
+        if (!\is_array($rowsets)) {
+            return $this->values(\func_get_args());
+        }
+
+        if ($rowsets === []) {
+            return $this;
+        }
+
+        //Checking if provided set is array of multiple
+        \reset($rowsets);
+
+        if (!\is_array($rowsets[\key($rowsets)])) {
+            if ($this->columns === []) {
+                $this->columns = \array_keys($rowsets);
+            }
+
+            $this->values[] = new Parameter(\array_values($rowsets));
+        } else {
+            if ($this->columns === []) {
+                $this->columns = \array_keys($rowsets[\key($rowsets)]);
+            }
+
+            foreach ($rowsets as $values) {
+                $this->values[] = new Parameter(\array_values($values));
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Defines an alias name when performing an upsert. By default, and when specified as NULL
+     * a unique value will be generated and used in its place.
+     *
+     * Examples:
+     * $upsert->alias("foo");
+     */
+    public function alias(?string $alias): self
+    {
+        $this->alias = $alias;
+        return $this;
+    }
+
+    /**
+     * Run the query and return last insert id.
+     * Returns an assoc array of values if multiple columns were specified as returning columns.
+     *
+     * @return array<non-empty-string, mixed>|int|non-empty-string|null
+     */
+    public function run(): mixed
+    {
+        $params = new QueryParameters();
+        $queryString = $this->sqlStatement($params);
+
+        $this->driver->execute(
+            $queryString,
+            $params->getParameters(),
+        );
+
+        $lastID = $this->driver->lastInsertID();
+        if (\is_numeric($lastID)) {
+            return (int) $lastID;
+        }
+
+        return $lastID;
+    }
+
+    public function getType(): int
+    {
+        return CompilerInterface::UPSERT_QUERY;
+    }
+
+    public function getTokens(): array
+    {
+        return [
+            'table'   => $this->table,
+            'columns' => $this->columns,
+            'values'  => $this->values,
+            'alias'   => $this->alias,
+        ];
+    }
+}

--- a/src/Query/UpsertQuery.php
+++ b/src/Query/UpsertQuery.php
@@ -10,9 +10,11 @@ use Cycle\Database\Injection\Parameter;
 class UpsertQuery extends ActiveQuery
 {
     protected string $table;
-    protected array $columns = [];
-    protected array $values  = [];
-    protected ?string $alias = null;
+    protected array $columns   = [];
+    protected array $values    = [];
+    protected array $conflicts = [];
+    protected string $target   = 'target';
+    protected string $source   = 'source';
 
     public function __construct(?string $table = null)
     {
@@ -102,15 +104,44 @@ class UpsertQuery extends ActiveQuery
     }
 
     /**
-     * Defines an alias name when performing an upsert. By default, and when specified as NULL
-     * a unique value will be generated and used in its place.
+     * Set upsert conflicting index column names. Names can be provided as array, set of parameters or comma
+     * separated string.
      *
      * Examples:
-     * $upsert->alias("foo");
+     * $upsert->conflicts(["identifier", "email"]);
+     * $upsert->conflicts("identifier", "email");
+     * $upsert->conflicts("identifier, email");
      */
-    public function alias(?string $alias): self
+    public function conflicts(array|string ...$conflicts): self
     {
-        $this->alias = $alias;
+        $this->conflicts = $this->fetchIdentifiers($conflicts);
+
+        return $this;
+    }
+
+    /**
+     * Set a target name when performing an upsert.
+     *
+     * Examples:
+     * $upsert->target("foo");
+     */
+    public function target(?string $target): self
+    {
+        $this->target = $target;
+
+        return $this;
+    }
+
+    /**
+     * Set a source name when performing an upsert.
+     *
+     * Examples:
+     * $upsert->source("bar");
+     */
+    public function source(?string $target): self
+    {
+        $this->target = $target;
+
         return $this;
     }
 
@@ -146,10 +177,12 @@ class UpsertQuery extends ActiveQuery
     public function getTokens(): array
     {
         return [
-            'table'   => $this->table,
-            'columns' => $this->columns,
-            'values'  => $this->values,
-            'alias'   => $this->alias,
+            'table'     => $this->table,
+            'columns'   => $this->columns,
+            'values'    => $this->values,
+            'conflicts' => $this->conflicts,
+            'target'    => $this->target,
+            'source'    => $this->source,
         ];
     }
 }

--- a/src/Query/UpsertQuery.php
+++ b/src/Query/UpsertQuery.php
@@ -13,8 +13,6 @@ class UpsertQuery extends ActiveQuery
     protected array $columns   = [];
     protected array $values    = [];
     protected array $conflicts = [];
-    protected string $target   = 'target';
-    protected string $source   = 'source';
 
     public function __construct(?string $table = null)
     {
@@ -120,32 +118,6 @@ class UpsertQuery extends ActiveQuery
     }
 
     /**
-     * Set a target name when performing an upsert.
-     *
-     * Examples:
-     * $upsert->target("foo");
-     */
-    public function target(?string $target): self
-    {
-        $this->target = $target;
-
-        return $this;
-    }
-
-    /**
-     * Set a source name when performing an upsert.
-     *
-     * Examples:
-     * $upsert->source("bar");
-     */
-    public function source(?string $target): self
-    {
-        $this->target = $target;
-
-        return $this;
-    }
-
-    /**
      * Run the query and return last insert id.
      * Returns an assoc array of values if multiple columns were specified as returning columns.
      *
@@ -181,8 +153,6 @@ class UpsertQuery extends ActiveQuery
             'columns'   => $this->columns,
             'values'    => $this->values,
             'conflicts' => $this->conflicts,
-            'target'    => $this->target,
-            'source'    => $this->source,
         ];
     }
 }

--- a/src/Table.php
+++ b/src/Table.php
@@ -16,6 +16,7 @@ use Cycle\Database\Query\DeleteQuery;
 use Cycle\Database\Query\InsertQuery;
 use Cycle\Database\Query\SelectQuery;
 use Cycle\Database\Query\UpdateQuery;
+use Cycle\Database\Query\UpsertQuery;
 use Cycle\Database\Schema\AbstractTable;
 
 /**
@@ -127,12 +128,56 @@ final class Table implements TableInterface, \IteratorAggregate, \Countable
     }
 
     /**
+     * Upsert one fieldset into table and return last inserted id.
+     *
+     * Example:
+     * $table->upsertOne(["name" => "Wolfy-J", "balance" => 10]);
+     *
+     * @throws BuilderException
+     */
+    public function upsertOne(array $rowset = []): int|string|null
+    {
+        return $this->database
+            ->upsert($this->name)
+            ->values($rowset)
+            ->run();
+    }
+
+    /**
+     * Perform batch upsert into table, every rowset should have identical amount of values matched
+     * with column names provided in first argument. Method will return lastInsertID on success.
+     *
+     * Example:
+     * $table->insertMultiple(["name", "balance"], array(["Bob", 10], ["Jack", 20]))
+     *
+     * @param array $columns Array of columns.
+     * @param array $rowsets Array of rowsets.
+     */
+    public function upsertMultiple(array $columns = [], array $rowsets = []): void
+    {
+        $this->database
+            ->upsert($this->name)
+            ->columns($columns)
+            ->values($rowsets)
+            ->run();
+    }
+
+    /**
      * Get insert builder specific to current table.
      */
     public function insert(): InsertQuery
     {
         return $this->database
             ->insert($this->name);
+    }
+
+    /**
+     * Get upsert builder specific to current table.
+     */
+    public function upsert(): UpsertQuery
+    {
+        return $this->database
+            ->upsert($this->name);
     }
 
     /**

--- a/tests/Database/Functional/Driver/Common/Query/UpsertQueryTest.php
+++ b/tests/Database/Functional/Driver/Common/Query/UpsertQueryTest.php
@@ -14,172 +14,38 @@ use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
 
 abstract class UpsertQueryTest extends BaseTest
 {
-    public const UPSERT_CLAUSE = 'ON DUPLICATE KEY UPDATE';
-
-    public static function queryWithValuesDataProvider(): array
-    {
-        return [
-            'compile' => [
-                'table'    => 'table',
-                'alias'    => 'target',
-                'values'   => ['name' => 'Adam'],
-                'compile'  => true,
-                'expected' => \sprintf('INSERT INTO {table} ({name}) VALUES (\'Adam\') AS {target} %s {name} = {target}.{name}', static::UPSERT_CLAUSE),
-            ],
-            'upsert'  => [
-                'table'    => 'table',
-                'alias'    => 'target',
-                'values'   => ['name' => 'Adam'],
-                'compile'  => false,
-                'expected' => \sprintf('INSERT INTO {table} ({name}) VALUES (?) AS {target} %s {name} = {target}.{name}', static::UPSERT_CLAUSE),
-            ],
-        ];
-    }
-
-    public static function queryWithStatesValuesDataProvider(): array
-    {
-        return [
-            'compile' => [
-                'table'    => 'table',
-                'alias'    => 'target',
-                'columns'  => ['name', 'balance'],
-                'values'   => ['Adam', 400],
-                'compile'  => true,
-                'expected' => \sprintf('INSERT INTO {table} ({name}, {balance}) VALUES (\'Adam\', 400) AS {target} %s {name} = {target}.{name}, {balance} = {target}.{balance}', static::UPSERT_CLAUSE),
-            ],
-            'upsert'  => [
-                'table'    => 'table',
-                'alias'    => 'target',
-                'columns'  => ['name', 'balance'],
-                'values'   => ['Adam', 400],
-                'compile'  => false,
-                'expected' => \sprintf('INSERT INTO {table} ({name}, {balance}) VALUES (?, ?) AS {target} %s {name} = {target}.{name}, {balance} = {target}.{balance}', static::UPSERT_CLAUSE),
-            ],
-        ];
-    }
-
-    public static function queryWithMultipleRowsDataProvider(): array
-    {
-        return [
-            'compile' => [
-                'table'    => 'table',
-                'alias'    => 'target',
-                'columns'  => ['name', 'balance'],
-                'values'   => [
-                    ['Adam', 400],
-                    ['John', 200],
-                ],
-                'compile'  => true,
-                'expected' => \sprintf('INSERT INTO {table} ({name}, {balance}) VALUES (\'Adam\', 400), (\'John\', 200) AS {target} %s {name} = {target}.{name}, {balance} = {target}.{balance}', static::UPSERT_CLAUSE),
-            ],
-            'upsert'  => [
-                'table'    => 'table',
-                'alias'    => 'target',
-                'columns'  => ['name', 'balance'],
-                'values'   => [
-                    ['Adam', 400],
-                    ['John', 200],
-                ],
-                'compile'  => false,
-                'expected' => \sprintf('INSERT INTO {table} ({name}, {balance}) VALUES (?, ?), (?, ?) AS {target} %s {name} = {target}.{name}, {balance} = {target}.{balance}', static::UPSERT_CLAUSE),
-            ],
-        ];
-    }
-
-    public static function queryWithMultipleRowsAsArrayDataProvider(): array
-    {
-        return [
-            'compile' => [
-                'table'    => 'table',
-                'alias'    => 'target',
-                'columns'  => ['name', 'balance'],
-                'values'   => [
-                    ['name' => 'Adam', 'balance' => 400],
-                    ['name' => 'John', 'balance' => 200],
-                ],
-                'compile'  => true,
-                'expected' => \sprintf('INSERT INTO {table} ({name}, {balance}) VALUES (\'Adam\', 400), (\'John\', 200) AS {target} %s {name} = {target}.{name}, {balance} = {target}.{balance}', static::UPSERT_CLAUSE),
-            ],
-            'upsert' => [
-                'table'    => 'table',
-                'alias'    => 'target',
-                'columns'  => ['name', 'balance'],
-                'values'   => [
-                    ['name' => 'Adam', 'balance' => 400],
-                    ['name' => 'John', 'balance' => 200],
-                ],
-                'compile'  => false,
-                'expected' => \sprintf('INSERT INTO {table} ({name}, {balance}) VALUES (?, ?), (?, ?) AS {target} %s {name} = {target}.{name}, {balance} = {target}.{balance}', static::UPSERT_CLAUSE),
-            ],
-            'expression' => [
-                'table'    => 'table',
-                'alias'    => 'target',
-                'columns'  => ['name', 'created_at', 'updated_at', 'deleted_at'],
-                'values'   => [
-                    'name' => 'Adam',
-                    'created_at' => new Expression('NOW()'),
-                    'updated_at' => new Expression('NOW()'),
-                    'deleted_at' => null,
-                ],
-                'compile'  => false,
-                'expected' => \sprintf('INSERT INTO {table} ({name}, {created_at}, {updated_at}, {deleted_at}) VALUES (?, NOW(), NOW(), ?) AS {target} %s {name} = {target}.{name}, {created_at} = {target}.{created_at}, {updated_at} = {target}.{updated_at}, {deleted_at} = {target}.{deleted_at}', static::UPSERT_CLAUSE),
-                'params'   => ['Adam', null],
-            ],
-            'fragment' => [
-                'table'    => 'table',
-                'alias'    => 'target',
-                'columns'  => ['name', 'created_at', 'updated_at', 'deleted_at'],
-                'values'   => [
-                    'name' => 'Adam',
-                    'created_at' => new Fragment('NOW()'),
-                    'updated_at' => new Fragment('NOW()'),
-                    'deleted_at' => new Fragment('datetime(\'now\')'),
-                ],
-                'compile'  => false,
-                'expected' => \sprintf('INSERT INTO {table} ({name}, {created_at}, {updated_at}, {deleted_at}) VALUES (?, NOW(), NOW(), datetime(\'now\')) AS {target} %s {name} = {target}.{name}, {created_at} = {target}.{created_at}, {updated_at} = {target}.{updated_at}, {deleted_at} = {target}.{deleted_at}', static::UPSERT_CLAUSE),
-            ],
-        ];
-    }
-
-    public static function queryWithCustomFragmentDataProvider(): array
-    {
-        return [
-            'compile' => [
-                'table'    => 'table',
-                'alias'    => 'target',
-                'columns'  => ['name', 'updated_at'],
-                'values'   => [
-                    'name' => 'Adam',
-                ],
-                'compile'  => true,
-                'expected' => \sprintf(\sprintf('INSERT INTO {table} ({name}, {updated_at}) VALUES (\'Adam\', NOW()) AS {target} %s {name} = {target}.{name}, {updated_at} = {target}.{updated_at}', static::UPSERT_CLAUSE), static::UPSERT_CLAUSE),
-                'params'   => ['Adam'],
-            ],
-            'upsert' => [
-                'table'    => 'table',
-                'alias'    => 'target',
-                'columns'  => ['name', 'updated_at'],
-                'values'   => [
-                    'name' => 'Adam',
-                ],
-                'compile'  => false,
-                'expected' => \sprintf(\sprintf('INSERT INTO {table} ({name}, {updated_at}) VALUES (?, NOW()) AS {target} %s {name} = {target}.{name}, {updated_at} = {target}.{updated_at}', static::UPSERT_CLAUSE), static::UPSERT_CLAUSE),
-                'params'   => ['Adam'],
-            ],
-        ];
-    }
+    protected const QUERY_INSTANCE             = UpsertQuery::class;
+    protected const QUERY_REQUIRES_CONFLICTS   = true;
+    protected const QUERY_WITH_VALUES          = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?) AS {target} ON CONFLICT ({email}) DO UPDATE SET {email} = {target}.{email}, {name} = {target}.{name}';
+    protected const QUERY_WITH_STATES_VALUES   = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?) AS {target} ON CONFLICT ({email}) DO UPDATE SET {email} = {target}.{email}, {name} = {target}.{name}';
+    protected const QUERY_WITH_MULTIPLE_ROWS   = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?), (?, ?) AS {target} ON CONFLICT ({email}) DO UPDATE SET {email} = {target}.{email}, {name} = {target}.{name}';
+    protected const QUERY_WITH_EXPRESSIONS     = 'INSERT INTO {table} ({email}, {name}, {created_at}, {updated_at}, {deleted_at}) VALUES (?, ?, NOW(), NOW(), ?) AS {target} ON CONFLICT ({email}) DO UPDATE SET {email} = {target}.{email}, {name} = {target}.{name}, {created_at} = {target}.{created_at}, {updated_at} = {target}.{updated_at}, {deleted_at} = {target}.{deleted_at}';
+    protected const QUERY_WITH_FRAGMENTS       = 'INSERT INTO {table} ({email}, {name}, {created_at}, {updated_at}, {deleted_at}) VALUES (?, ?, NOW(), datetime(\'now\'), ?) AS {target} ON CONFLICT ({email}) DO UPDATE SET {email} = {target}.{email}, {name} = {target}.{name}, {created_at} = {target}.{created_at}, {updated_at} = {target}.{updated_at}, {deleted_at} = {target}.{deleted_at}';
+    protected const QUERY_WITH_CUSTOM_FRAGMENT = 'INSERT INTO {table} ({email}, {name}, {expired_at}) VALUES (?, ?, NOW()) AS {target} ON CONFLICT ({email}) DO UPDATE SET {email} = {target}.{email}, {name} = {target}.{name}, {expired_at} = {target}.{expired_at}';
 
     public function testQueryInstance(): void
     {
-        $this->assertInstanceOf(
-            UpsertQuery::class,
-            $this->database->upsert(),
-        );
+        $this->assertInstanceOf(static::QUERY_INSTANCE, $this->database->upsert());
+        $this->assertInstanceOf(static::QUERY_INSTANCE, $this->database->table->upsert());
+    }
 
-        $this->assertInstanceOf(
-            UpsertQuery::class,
-            $this->database->table->upsert(),
-        );
+    public function testNoConflictsThrowsException(): void
+    {
+        if (static::QUERY_REQUIRES_CONFLICTS) {
+            $this->expectException(CompilerException::class);
+            $this->expectExceptionMessage('Upsert query must define conflicting index column names');
+
+            $this->db()->upsert('table')
+                ->target('target')
+                ->values(
+                    [
+                        'email' => 'adam@email.com',
+                        'name' => 'Adam',
+                    ],
+                )->__toString();
+        } else {
+            $this->assertFalse(static::QUERY_REQUIRES_CONFLICTS);
+        }
     }
 
     public function testNoColumnsThrowsException(): void
@@ -187,101 +53,103 @@ abstract class UpsertQueryTest extends BaseTest
         $this->expectException(CompilerException::class);
         $this->expectExceptionMessage('Upsert query must define at least one column');
 
-        $this->db()->upsert('table')->values([])->__toString();
+        $this->db()->upsert('table')
+            ->target('target')
+            ->conflicts('email')
+            ->values([])->__toString();
     }
 
-    /**
-     * @dataProvider queryWithValuesDataProvider
-     */
-    public function testQueryWithValues(
-        string $table,
-        string $alias,
-        array $values,
-        bool $compile,
-        string $expected,
-    ): void {
-        $upsert = $this->db()->upsert($table)->alias($alias)->values($values);
+    public function testQueryWithValues(): void
+    {
+        $upsert = $this->db()->upsert('table')
+            ->target('target')
+            ->conflicts('email')
+            ->values(
+                [
+                    'email' => 'adam@email.com',
+                    'name' => 'Adam',
+                ],
+            );
 
-        $actual = $compile ? $upsert->__toString() : $upsert;
-
-        $this->assertSameQuery($expected, $actual);
+        $this->assertSameQuery(static::QUERY_WITH_VALUES, $upsert);
+        $this->assertSameParameters(['adam@email.com', 'Adam'], $upsert);
     }
 
-    /**
-     * @dataProvider queryWithStatesValuesDataProvider
-     */
-    public function testQueryWithStatesValues(
-        string $table,
-        string $alias,
-        array $columns,
-        array $values,
-        bool $compile,
-        string $expected,
-    ): void {
-        $upsert = $this->database->upsert()->into($table)->alias($alias)->columns(...$columns)->values(...$values);
+    public function testQueryWithStatesValues(): void
+    {
+        $upsert = $this->database->upsert('table')
+            ->target('target')
+            ->conflicts('email')
+            ->columns('email', 'name')
+            ->values('adam@email.com', 'Adam');
 
-        $actual = $compile ? $upsert->__toString() : $upsert;
-
-        $this->assertSameQuery($expected, $actual);
+        $this->assertSameQuery(static::QUERY_WITH_STATES_VALUES, $upsert);
+        $this->assertSameParameters(['adam@email.com', 'Adam'], $upsert);
     }
 
-    /**
-     * @dataProvider queryWithMultipleRowsDataProvider
-     */
-    public function testQueryWithMultipleRows(
-        string $table,
-        string $alias,
-        array $columns,
-        array $values,
-        bool $compile,
-        string $expected,
-    ): void {
-        $upsert = $this->database->upsert()->into($table)->alias($alias)->columns(...$columns);
+    public function testQueryWithMultipleRows(): void
+    {
+        $upsert = $this->database->upsert('table')
+            ->target('target')
+            ->conflicts('email')
+            ->columns('email', 'name')
+            ->values('adam@email.com', 'Adam')
+            ->values('bill@email.com', 'Bill');
 
-        foreach ($values as $row) {
-            $upsert->values(...$row);
-        }
-
-        $actual = $compile ? $upsert->__toString() : $upsert;
-
-        $this->assertSameQuery($expected, $actual);
+        $this->assertSameQuery(static::QUERY_WITH_MULTIPLE_ROWS, $upsert);
+        $this->assertSameParameters(['adam@email.com', 'Adam', 'bill@email.com', 'Bill'], $upsert);
     }
 
-    /**
-     * @dataProvider queryWithMultipleRowsAsArrayDataProvider
-     */
-    public function testQueryWithMultipleRowsAsArray(
-        string $table,
-        string $alias,
-        array $columns,
-        array $values,
-        bool $compile,
-        string $expected,
-        ?array $params = null,
-    ): void {
-        $upsert = $this->database->upsert()->into($table)->alias($alias)->columns(...$columns)->values($values);
+    public function testQueryWithMultipleRowsAsArray(): void
+    {
+        $upsert = $this->database->upsert('table')
+            ->target('target')
+            ->conflicts('email')
+            ->values([
+                ['email' => 'adam@email.com', 'name' => 'Adam'],
+                ['email' => 'bill@email.com', 'name' => 'Bill'],
+            ]);
 
-        $actual = $compile ? $upsert->__toString() : $upsert;
-
-        $this->assertSameQuery($expected, $actual);
-
-        if ($params !== null) {
-            $this->assertSameParameters($params, $upsert);
-        }
+        $this->assertSameQuery(static::QUERY_WITH_MULTIPLE_ROWS, $upsert);
+        $this->assertSameParameters(['adam@email.com', 'Adam', 'bill@email.com', 'Bill'], $upsert);
     }
 
-    /**
-     * @dataProvider queryWithCustomFragmentDataProvider
-     */
-    public function testQueryWithCustomFragment(
-        string $table,
-        string $alias,
-        array $columns,
-        array $values,
-        bool $compile,
-        string $expected,
-        ?array $params = null,
-    ): void {
+    public function testQueryWithExpressions(): void
+    {
+        $upsert = $this->database->upsert('table')
+            ->target('target')
+            ->conflicts('email')
+            ->values([
+                'email' => 'adam@email.com',
+                'name' => 'Adam',
+                'created_at' => new Expression('NOW()'),
+                'updated_at' => new Expression('NOW()'),
+                'deleted_at' => null,
+            ]);
+
+        $this->assertSameQuery(static::QUERY_WITH_EXPRESSIONS, $upsert);
+        $this->assertSameParameters(['adam@email.com', 'Adam', null], $upsert);
+    }
+
+    public function testQueryWithFragments(): void
+    {
+        $upsert = $this->database->upsert('table')
+            ->target('target')
+            ->conflicts('email')
+            ->values([
+                'email' => 'adam@email.com',
+                'name' => 'Adam',
+                'created_at' => new Fragment('NOW()'),
+                'updated_at' => new Fragment('datetime(\'now\')'),
+                'deleted_at' => null,
+            ]);
+
+        $this->assertSameQuery(static::QUERY_WITH_FRAGMENTS, $upsert);
+        $this->assertSameParameters(['adam@email.com', 'Adam', null], $upsert);
+    }
+
+    public function testQueryWithCustomFragment(): void
+    {
         $fragment = $this->createMock(FragmentInterface::class);
         $fragment->method('getType')->willReturn(CompilerInterface::FRAGMENT);
         $fragment->method('getTokens')->willReturn([
@@ -289,25 +157,16 @@ abstract class UpsertQueryTest extends BaseTest
             'parameters' => [],
         ]);
 
-        $values['updated_at'] = $fragment;
+        $upsert = $this->database->upsert('table')
+            ->target('target')
+            ->conflicts('email')
+            ->values([
+                'email' => 'adam@email.com',
+                'name' => 'Adam',
+                'expired_at' => $fragment,
+            ]);
 
-        $upsert = $this->database->upsert()->into($table)->alias($alias)->columns(...$columns)->values($values);
-        $actual = $compile ? $upsert->__toString() : $upsert;
-
-        $this->assertSameQuery($expected, $actual);
-
-        if ($params !== null) {
-            $this->assertSameParameters($params, $upsert);
-        }
-
-        // cached query
-        $upsert = $this->database->upsert()->into($table)->alias($alias)->columns(...$columns)->values($values);
-        $actual = $compile ? $upsert->__toString() : $upsert;
-
-        $this->assertSameQuery($expected, $actual);
-
-        if ($params !== null) {
-            $this->assertSameParameters($params, $upsert);
-        }
+        $this->assertSameQuery(static::QUERY_WITH_CUSTOM_FRAGMENT, $upsert);
+        $this->assertSameParameters(['adam@email.com', 'Adam'], $upsert);
     }
 }

--- a/tests/Database/Functional/Driver/Common/Query/UpsertQueryTest.php
+++ b/tests/Database/Functional/Driver/Common/Query/UpsertQueryTest.php
@@ -1,0 +1,313 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\Common\Query;
+
+use Cycle\Database\Driver\CompilerInterface;
+use Cycle\Database\Exception\CompilerException;
+use Cycle\Database\Injection\Expression;
+use Cycle\Database\Injection\Fragment;
+use Cycle\Database\Injection\FragmentInterface;
+use Cycle\Database\Query\UpsertQuery;
+use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
+
+abstract class UpsertQueryTest extends BaseTest
+{
+    public const UPSERT_CLAUSE = 'ON DUPLICATE KEY UPDATE';
+
+    public static function queryWithValuesDataProvider(): array
+    {
+        return [
+            'compile' => [
+                'table'    => 'table',
+                'alias'    => 'target',
+                'values'   => ['name' => 'Adam'],
+                'compile'  => true,
+                'expected' => \sprintf('INSERT INTO {table} ({name}) VALUES (\'Adam\') AS {target} %s {name} = {target}.{name}', static::UPSERT_CLAUSE),
+            ],
+            'upsert'  => [
+                'table'    => 'table',
+                'alias'    => 'target',
+                'values'   => ['name' => 'Adam'],
+                'compile'  => false,
+                'expected' => \sprintf('INSERT INTO {table} ({name}) VALUES (?) AS {target} %s {name} = {target}.{name}', static::UPSERT_CLAUSE),
+            ],
+        ];
+    }
+
+    public static function queryWithStatesValuesDataProvider(): array
+    {
+        return [
+            'compile' => [
+                'table'    => 'table',
+                'alias'    => 'target',
+                'columns'  => ['name', 'balance'],
+                'values'   => ['Adam', 400],
+                'compile'  => true,
+                'expected' => \sprintf('INSERT INTO {table} ({name}, {balance}) VALUES (\'Adam\', 400) AS {target} %s {name} = {target}.{name}, {balance} = {target}.{balance}', static::UPSERT_CLAUSE),
+            ],
+            'upsert'  => [
+                'table'    => 'table',
+                'alias'    => 'target',
+                'columns'  => ['name', 'balance'],
+                'values'   => ['Adam', 400],
+                'compile'  => false,
+                'expected' => \sprintf('INSERT INTO {table} ({name}, {balance}) VALUES (?, ?) AS {target} %s {name} = {target}.{name}, {balance} = {target}.{balance}', static::UPSERT_CLAUSE),
+            ],
+        ];
+    }
+
+    public static function queryWithMultipleRowsDataProvider(): array
+    {
+        return [
+            'compile' => [
+                'table'    => 'table',
+                'alias'    => 'target',
+                'columns'  => ['name', 'balance'],
+                'values'   => [
+                    ['Adam', 400],
+                    ['John', 200],
+                ],
+                'compile'  => true,
+                'expected' => \sprintf('INSERT INTO {table} ({name}, {balance}) VALUES (\'Adam\', 400), (\'John\', 200) AS {target} %s {name} = {target}.{name}, {balance} = {target}.{balance}', static::UPSERT_CLAUSE),
+            ],
+            'upsert'  => [
+                'table'    => 'table',
+                'alias'    => 'target',
+                'columns'  => ['name', 'balance'],
+                'values'   => [
+                    ['Adam', 400],
+                    ['John', 200],
+                ],
+                'compile'  => false,
+                'expected' => \sprintf('INSERT INTO {table} ({name}, {balance}) VALUES (?, ?), (?, ?) AS {target} %s {name} = {target}.{name}, {balance} = {target}.{balance}', static::UPSERT_CLAUSE),
+            ],
+        ];
+    }
+
+    public static function queryWithMultipleRowsAsArrayDataProvider(): array
+    {
+        return [
+            'compile' => [
+                'table'    => 'table',
+                'alias'    => 'target',
+                'columns'  => ['name', 'balance'],
+                'values'   => [
+                    ['name' => 'Adam', 'balance' => 400],
+                    ['name' => 'John', 'balance' => 200],
+                ],
+                'compile'  => true,
+                'expected' => \sprintf('INSERT INTO {table} ({name}, {balance}) VALUES (\'Adam\', 400), (\'John\', 200) AS {target} %s {name} = {target}.{name}, {balance} = {target}.{balance}', static::UPSERT_CLAUSE),
+            ],
+            'upsert' => [
+                'table'    => 'table',
+                'alias'    => 'target',
+                'columns'  => ['name', 'balance'],
+                'values'   => [
+                    ['name' => 'Adam', 'balance' => 400],
+                    ['name' => 'John', 'balance' => 200],
+                ],
+                'compile'  => false,
+                'expected' => \sprintf('INSERT INTO {table} ({name}, {balance}) VALUES (?, ?), (?, ?) AS {target} %s {name} = {target}.{name}, {balance} = {target}.{balance}', static::UPSERT_CLAUSE),
+            ],
+            'expression' => [
+                'table'    => 'table',
+                'alias'    => 'target',
+                'columns'  => ['name', 'created_at', 'updated_at', 'deleted_at'],
+                'values'   => [
+                    'name' => 'Adam',
+                    'created_at' => new Expression('NOW()'),
+                    'updated_at' => new Expression('NOW()'),
+                    'deleted_at' => null,
+                ],
+                'compile'  => false,
+                'expected' => \sprintf('INSERT INTO {table} ({name}, {created_at}, {updated_at}, {deleted_at}) VALUES (?, NOW(), NOW(), ?) AS {target} %s {name} = {target}.{name}, {created_at} = {target}.{created_at}, {updated_at} = {target}.{updated_at}, {deleted_at} = {target}.{deleted_at}', static::UPSERT_CLAUSE),
+                'params'   => ['Adam', null],
+            ],
+            'fragment' => [
+                'table'    => 'table',
+                'alias'    => 'target',
+                'columns'  => ['name', 'created_at', 'updated_at', 'deleted_at'],
+                'values'   => [
+                    'name' => 'Adam',
+                    'created_at' => new Fragment('NOW()'),
+                    'updated_at' => new Fragment('NOW()'),
+                    'deleted_at' => new Fragment('datetime(\'now\')'),
+                ],
+                'compile'  => false,
+                'expected' => \sprintf('INSERT INTO {table} ({name}, {created_at}, {updated_at}, {deleted_at}) VALUES (?, NOW(), NOW(), datetime(\'now\')) AS {target} %s {name} = {target}.{name}, {created_at} = {target}.{created_at}, {updated_at} = {target}.{updated_at}, {deleted_at} = {target}.{deleted_at}', static::UPSERT_CLAUSE),
+            ],
+        ];
+    }
+
+    public static function queryWithCustomFragmentDataProvider(): array
+    {
+        return [
+            'compile' => [
+                'table'    => 'table',
+                'alias'    => 'target',
+                'columns'  => ['name', 'updated_at'],
+                'values'   => [
+                    'name' => 'Adam',
+                ],
+                'compile'  => true,
+                'expected' => \sprintf(\sprintf('INSERT INTO {table} ({name}, {updated_at}) VALUES (\'Adam\', NOW()) AS {target} %s {name} = {target}.{name}, {updated_at} = {target}.{updated_at}', static::UPSERT_CLAUSE), static::UPSERT_CLAUSE),
+                'params'   => ['Adam'],
+            ],
+            'upsert' => [
+                'table'    => 'table',
+                'alias'    => 'target',
+                'columns'  => ['name', 'updated_at'],
+                'values'   => [
+                    'name' => 'Adam',
+                ],
+                'compile'  => false,
+                'expected' => \sprintf(\sprintf('INSERT INTO {table} ({name}, {updated_at}) VALUES (?, NOW()) AS {target} %s {name} = {target}.{name}, {updated_at} = {target}.{updated_at}', static::UPSERT_CLAUSE), static::UPSERT_CLAUSE),
+                'params'   => ['Adam'],
+            ],
+        ];
+    }
+
+    public function testQueryInstance(): void
+    {
+        $this->assertInstanceOf(
+            UpsertQuery::class,
+            $this->database->upsert(),
+        );
+
+        $this->assertInstanceOf(
+            UpsertQuery::class,
+            $this->database->table->upsert(),
+        );
+    }
+
+    public function testNoColumnsThrowsException(): void
+    {
+        $this->expectException(CompilerException::class);
+        $this->expectExceptionMessage('Upsert query must define at least one column');
+
+        $this->db()->upsert('table')->values([])->__toString();
+    }
+
+    /**
+     * @dataProvider queryWithValuesDataProvider
+     */
+    public function testQueryWithValues(
+        string $table,
+        string $alias,
+        array $values,
+        bool $compile,
+        string $expected,
+    ): void {
+        $upsert = $this->db()->upsert($table)->alias($alias)->values($values);
+
+        $actual = $compile ? $upsert->__toString() : $upsert;
+
+        $this->assertSameQuery($expected, $actual);
+    }
+
+    /**
+     * @dataProvider queryWithStatesValuesDataProvider
+     */
+    public function testQueryWithStatesValues(
+        string $table,
+        string $alias,
+        array $columns,
+        array $values,
+        bool $compile,
+        string $expected,
+    ): void {
+        $upsert = $this->database->upsert()->into($table)->alias($alias)->columns(...$columns)->values(...$values);
+
+        $actual = $compile ? $upsert->__toString() : $upsert;
+
+        $this->assertSameQuery($expected, $actual);
+    }
+
+    /**
+     * @dataProvider queryWithMultipleRowsDataProvider
+     */
+    public function testQueryWithMultipleRows(
+        string $table,
+        string $alias,
+        array $columns,
+        array $values,
+        bool $compile,
+        string $expected,
+    ): void {
+        $upsert = $this->database->upsert()->into($table)->alias($alias)->columns(...$columns);
+
+        foreach ($values as $row) {
+            $upsert->values(...$row);
+        }
+
+        $actual = $compile ? $upsert->__toString() : $upsert;
+
+        $this->assertSameQuery($expected, $actual);
+    }
+
+    /**
+     * @dataProvider queryWithMultipleRowsAsArrayDataProvider
+     */
+    public function testQueryWithMultipleRowsAsArray(
+        string $table,
+        string $alias,
+        array $columns,
+        array $values,
+        bool $compile,
+        string $expected,
+        ?array $params = null,
+    ): void {
+        $upsert = $this->database->upsert()->into($table)->alias($alias)->columns(...$columns)->values($values);
+
+        $actual = $compile ? $upsert->__toString() : $upsert;
+
+        $this->assertSameQuery($expected, $actual);
+
+        if ($params !== null) {
+            $this->assertSameParameters($params, $upsert);
+        }
+    }
+
+    /**
+     * @dataProvider queryWithCustomFragmentDataProvider
+     */
+    public function testQueryWithCustomFragment(
+        string $table,
+        string $alias,
+        array $columns,
+        array $values,
+        bool $compile,
+        string $expected,
+        ?array $params = null,
+    ): void {
+        $fragment = $this->createMock(FragmentInterface::class);
+        $fragment->method('getType')->willReturn(CompilerInterface::FRAGMENT);
+        $fragment->method('getTokens')->willReturn([
+            'fragment' => 'NOW()',
+            'parameters' => [],
+        ]);
+
+        $values['updated_at'] = $fragment;
+
+        $upsert = $this->database->upsert()->into($table)->alias($alias)->columns(...$columns)->values($values);
+        $actual = $compile ? $upsert->__toString() : $upsert;
+
+        $this->assertSameQuery($expected, $actual);
+
+        if ($params !== null) {
+            $this->assertSameParameters($params, $upsert);
+        }
+
+        // cached query
+        $upsert = $this->database->upsert()->into($table)->alias($alias)->columns(...$columns)->values($values);
+        $actual = $compile ? $upsert->__toString() : $upsert;
+
+        $this->assertSameQuery($expected, $actual);
+
+        if ($params !== null) {
+            $this->assertSameParameters($params, $upsert);
+        }
+    }
+}

--- a/tests/Database/Functional/Driver/Common/Query/UpsertQueryTest.php
+++ b/tests/Database/Functional/Driver/Common/Query/UpsertQueryTest.php
@@ -16,12 +16,12 @@ abstract class UpsertQueryTest extends BaseTest
 {
     protected const QUERY_INSTANCE             = UpsertQuery::class;
     protected const QUERY_REQUIRES_CONFLICTS   = true;
-    protected const QUERY_WITH_VALUES          = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?) AS {target} ON CONFLICT ({email}) DO UPDATE SET {email} = {target}.{email}, {name} = {target}.{name}';
-    protected const QUERY_WITH_STATES_VALUES   = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?) AS {target} ON CONFLICT ({email}) DO UPDATE SET {email} = {target}.{email}, {name} = {target}.{name}';
-    protected const QUERY_WITH_MULTIPLE_ROWS   = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?), (?, ?) AS {target} ON CONFLICT ({email}) DO UPDATE SET {email} = {target}.{email}, {name} = {target}.{name}';
-    protected const QUERY_WITH_EXPRESSIONS     = 'INSERT INTO {table} ({email}, {name}, {created_at}, {updated_at}, {deleted_at}) VALUES (?, ?, NOW(), NOW(), ?) AS {target} ON CONFLICT ({email}) DO UPDATE SET {email} = {target}.{email}, {name} = {target}.{name}, {created_at} = {target}.{created_at}, {updated_at} = {target}.{updated_at}, {deleted_at} = {target}.{deleted_at}';
-    protected const QUERY_WITH_FRAGMENTS       = 'INSERT INTO {table} ({email}, {name}, {created_at}, {updated_at}, {deleted_at}) VALUES (?, ?, NOW(), datetime(\'now\'), ?) AS {target} ON CONFLICT ({email}) DO UPDATE SET {email} = {target}.{email}, {name} = {target}.{name}, {created_at} = {target}.{created_at}, {updated_at} = {target}.{updated_at}, {deleted_at} = {target}.{deleted_at}';
-    protected const QUERY_WITH_CUSTOM_FRAGMENT = 'INSERT INTO {table} ({email}, {name}, {expired_at}) VALUES (?, ?, NOW()) AS {target} ON CONFLICT ({email}) DO UPDATE SET {email} = {target}.{email}, {name} = {target}.{name}, {expired_at} = {target}.{expired_at}';
+    protected const QUERY_WITH_VALUES          = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?) ON CONFLICT ({email}) DO UPDATE SET {email} = EXCLUDED.{email}, {name} = EXCLUDED.{name}';
+    protected const QUERY_WITH_STATES_VALUES   = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?) ON CONFLICT ({email}) DO UPDATE SET {email} = EXCLUDED.{email}, {name} = EXCLUDED.{name}';
+    protected const QUERY_WITH_MULTIPLE_ROWS   = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?), (?, ?) ON CONFLICT ({email}) DO UPDATE SET {email} = EXCLUDED.{email}, {name} = EXCLUDED.{name}';
+    protected const QUERY_WITH_EXPRESSIONS     = 'INSERT INTO {table} ({email}, {name}, {created_at}, {updated_at}, {deleted_at}) VALUES (?, ?, NOW(), NOW(), ?) ON CONFLICT ({email}) DO UPDATE SET {email} = EXCLUDED.{email}, {name} = EXCLUDED.{name}, {created_at} = EXCLUDED.{created_at}, {updated_at} = EXCLUDED.{updated_at}, {deleted_at} = EXCLUDED.{deleted_at}';
+    protected const QUERY_WITH_FRAGMENTS       = 'INSERT INTO {table} ({email}, {name}, {created_at}, {updated_at}, {deleted_at}) VALUES (?, ?, NOW(), datetime(\'now\'), ?) ON CONFLICT ({email}) DO UPDATE SET {email} = EXCLUDED.{email}, {name} = EXCLUDED.{name}, {created_at} = EXCLUDED.{created_at}, {updated_at} = EXCLUDED.{updated_at}, {deleted_at} = EXCLUDED.{deleted_at}';
+    protected const QUERY_WITH_CUSTOM_FRAGMENT = 'INSERT INTO {table} ({email}, {name}, {expired_at}) VALUES (?, ?, NOW()) ON CONFLICT ({email}) DO UPDATE SET {email} = EXCLUDED.{email}, {name} = EXCLUDED.{name}, {expired_at} = EXCLUDED.{expired_at}';
 
     public function testQueryInstance(): void
     {
@@ -36,7 +36,6 @@ abstract class UpsertQueryTest extends BaseTest
             $this->expectExceptionMessage('Upsert query must define conflicting index column names');
 
             $this->db()->upsert('table')
-                ->target('target')
                 ->values(
                     [
                         'email' => 'adam@email.com',
@@ -54,7 +53,6 @@ abstract class UpsertQueryTest extends BaseTest
         $this->expectExceptionMessage('Upsert query must define at least one column');
 
         $this->db()->upsert('table')
-            ->target('target')
             ->conflicts('email')
             ->values([])->__toString();
     }
@@ -62,7 +60,6 @@ abstract class UpsertQueryTest extends BaseTest
     public function testQueryWithValues(): void
     {
         $upsert = $this->db()->upsert('table')
-            ->target('target')
             ->conflicts('email')
             ->values(
                 [
@@ -78,7 +75,6 @@ abstract class UpsertQueryTest extends BaseTest
     public function testQueryWithStatesValues(): void
     {
         $upsert = $this->database->upsert('table')
-            ->target('target')
             ->conflicts('email')
             ->columns('email', 'name')
             ->values('adam@email.com', 'Adam');
@@ -90,7 +86,6 @@ abstract class UpsertQueryTest extends BaseTest
     public function testQueryWithMultipleRows(): void
     {
         $upsert = $this->database->upsert('table')
-            ->target('target')
             ->conflicts('email')
             ->columns('email', 'name')
             ->values('adam@email.com', 'Adam')
@@ -103,7 +98,6 @@ abstract class UpsertQueryTest extends BaseTest
     public function testQueryWithMultipleRowsAsArray(): void
     {
         $upsert = $this->database->upsert('table')
-            ->target('target')
             ->conflicts('email')
             ->values([
                 ['email' => 'adam@email.com', 'name' => 'Adam'],
@@ -117,7 +111,6 @@ abstract class UpsertQueryTest extends BaseTest
     public function testQueryWithExpressions(): void
     {
         $upsert = $this->database->upsert('table')
-            ->target('target')
             ->conflicts('email')
             ->values([
                 'email' => 'adam@email.com',
@@ -134,7 +127,6 @@ abstract class UpsertQueryTest extends BaseTest
     public function testQueryWithFragments(): void
     {
         $upsert = $this->database->upsert('table')
-            ->target('target')
             ->conflicts('email')
             ->values([
                 'email' => 'adam@email.com',
@@ -158,7 +150,6 @@ abstract class UpsertQueryTest extends BaseTest
         ]);
 
         $upsert = $this->database->upsert('table')
-            ->target('target')
             ->conflicts('email')
             ->values([
                 'email' => 'adam@email.com',

--- a/tests/Database/Functional/Driver/MySQL/Query/UpsertQueryTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Query/UpsertQueryTest.php
@@ -15,10 +15,10 @@ class UpsertQueryTest extends CommonClass
 {
     public const DRIVER = 'mysql';
     protected const QUERY_REQUIRES_CONFLICTS   = false;
-    protected const QUERY_WITH_VALUES          = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?) AS {target} ON DUPLICATE KEY UPDATE {email} = {target}.{email}, {name} = {target}.{name}';
-    protected const QUERY_WITH_STATES_VALUES   = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?) AS {target} ON DUPLICATE KEY UPDATE {email} = {target}.{email}, {name} = {target}.{name}';
-    protected const QUERY_WITH_MULTIPLE_ROWS   = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?), (?, ?) AS {target} ON DUPLICATE KEY UPDATE {email} = {target}.{email}, {name} = {target}.{name}';
-    protected const QUERY_WITH_EXPRESSIONS     = 'INSERT INTO {table} ({email}, {name}, {created_at}, {updated_at}, {deleted_at}) VALUES (?, ?, NOW(), NOW(), ?) AS {target} ON DUPLICATE KEY UPDATE {email} = {target}.{email}, {name} = {target}.{name}, {created_at} = {target}.{created_at}, {updated_at} = {target}.{updated_at}, {deleted_at} = {target}.{deleted_at}';
-    protected const QUERY_WITH_FRAGMENTS       = 'INSERT INTO {table} ({email}, {name}, {created_at}, {updated_at}, {deleted_at}) VALUES (?, ?, NOW(), datetime(\'now\'), ?) AS {target} ON DUPLICATE KEY UPDATE {email} = {target}.{email}, {name} = {target}.{name}, {created_at} = {target}.{created_at}, {updated_at} = {target}.{updated_at}, {deleted_at} = {target}.{deleted_at}';
-    protected const QUERY_WITH_CUSTOM_FRAGMENT = 'INSERT INTO {table} ({email}, {name}, {expired_at}) VALUES (?, ?, NOW()) AS {target} ON DUPLICATE KEY UPDATE {email} = {target}.{email}, {name} = {target}.{name}, {expired_at} = {target}.{expired_at}';
+    protected const QUERY_WITH_VALUES          = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?) ON DUPLICATE KEY UPDATE {email} = VALUES({email}), {name} = VALUES({name})';
+    protected const QUERY_WITH_STATES_VALUES   = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?) ON DUPLICATE KEY UPDATE {email} = VALUES({email}), {name} = VALUES({name})';
+    protected const QUERY_WITH_MULTIPLE_ROWS   = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?), (?, ?) ON DUPLICATE KEY UPDATE {email} = VALUES({email}), {name} = VALUES({name})';
+    protected const QUERY_WITH_EXPRESSIONS     = 'INSERT INTO {table} ({email}, {name}, {created_at}, {updated_at}, {deleted_at}) VALUES (?, ?, NOW(), NOW(), ?) ON DUPLICATE KEY UPDATE {email} = VALUES({email}), {name} = VALUES({name}), {created_at} = VALUES({created_at}), {updated_at} = VALUES({updated_at}), {deleted_at} = VALUES({deleted_at})';
+    protected const QUERY_WITH_FRAGMENTS       = 'INSERT INTO {table} ({email}, {name}, {created_at}, {updated_at}, {deleted_at}) VALUES (?, ?, NOW(), datetime(\'now\'), ?) ON DUPLICATE KEY UPDATE {email} = VALUES({email}), {name} = VALUES({name}), {created_at} = VALUES({created_at}), {updated_at} = VALUES({updated_at}), {deleted_at} = VALUES({deleted_at})';
+    protected const QUERY_WITH_CUSTOM_FRAGMENT = 'INSERT INTO {table} ({email}, {name}, {expired_at}) VALUES (?, ?, NOW()) ON DUPLICATE KEY UPDATE {email} = VALUES({email}), {name} = VALUES({name}), {expired_at} = VALUES({expired_at})';
 }

--- a/tests/Database/Functional/Driver/MySQL/Query/UpsertQueryTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Query/UpsertQueryTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\MySQL\Query;
+
+// phpcs:ignore
+use Cycle\Database\Tests\Functional\Driver\Common\Query\UpsertQueryTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class UpsertQueryTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/Database/Functional/Driver/MySQL/Query/UpsertQueryTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Query/UpsertQueryTest.php
@@ -14,4 +14,11 @@ use Cycle\Database\Tests\Functional\Driver\Common\Query\UpsertQueryTest as Commo
 class UpsertQueryTest extends CommonClass
 {
     public const DRIVER = 'mysql';
+    protected const QUERY_REQUIRES_CONFLICTS   = false;
+    protected const QUERY_WITH_VALUES          = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?) AS {target} ON DUPLICATE KEY UPDATE {email} = {target}.{email}, {name} = {target}.{name}';
+    protected const QUERY_WITH_STATES_VALUES   = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?) AS {target} ON DUPLICATE KEY UPDATE {email} = {target}.{email}, {name} = {target}.{name}';
+    protected const QUERY_WITH_MULTIPLE_ROWS   = 'INSERT INTO {table} ({email}, {name}) VALUES (?, ?), (?, ?) AS {target} ON DUPLICATE KEY UPDATE {email} = {target}.{email}, {name} = {target}.{name}';
+    protected const QUERY_WITH_EXPRESSIONS     = 'INSERT INTO {table} ({email}, {name}, {created_at}, {updated_at}, {deleted_at}) VALUES (?, ?, NOW(), NOW(), ?) AS {target} ON DUPLICATE KEY UPDATE {email} = {target}.{email}, {name} = {target}.{name}, {created_at} = {target}.{created_at}, {updated_at} = {target}.{updated_at}, {deleted_at} = {target}.{deleted_at}';
+    protected const QUERY_WITH_FRAGMENTS       = 'INSERT INTO {table} ({email}, {name}, {created_at}, {updated_at}, {deleted_at}) VALUES (?, ?, NOW(), datetime(\'now\'), ?) AS {target} ON DUPLICATE KEY UPDATE {email} = {target}.{email}, {name} = {target}.{name}, {created_at} = {target}.{created_at}, {updated_at} = {target}.{updated_at}, {deleted_at} = {target}.{deleted_at}';
+    protected const QUERY_WITH_CUSTOM_FRAGMENT = 'INSERT INTO {table} ({email}, {name}, {expired_at}) VALUES (?, ?, NOW()) AS {target} ON DUPLICATE KEY UPDATE {email} = {target}.{email}, {name} = {target}.{name}, {expired_at} = {target}.{expired_at}';
 }

--- a/tests/Database/Functional/Driver/Postgres/Query/UpsertQueryTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Query/UpsertQueryTest.php
@@ -15,12 +15,5 @@ use Cycle\Database\Tests\Functional\Driver\Common\Query\UpsertQueryTest as Commo
 class UpsertQueryTest extends CommonClass
 {
     public const DRIVER = 'postgres';
-    public const UPSERT_CLAUSE = 'ON CONFLICT DO UPDATE SET';
-
-    public function testQueryInstance(): void
-    {
-        parent::testQueryInstance();
-
-        $this->assertInstanceOf(PostgresUpsertQuery::class, $this->database->upsert());
-    }
+    protected const QUERY_INSTANCE = PostgresUpsertQuery::class;
 }

--- a/tests/Database/Functional/Driver/Postgres/Query/UpsertQueryTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Query/UpsertQueryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\Postgres\Query;
+
+// phpcs:ignore
+use Cycle\Database\Driver\Postgres\Query\PostgresUpsertQuery;
+use Cycle\Database\Tests\Functional\Driver\Common\Query\UpsertQueryTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class UpsertQueryTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+    public const UPSERT_CLAUSE = 'ON CONFLICT DO UPDATE SET';
+
+    public function testQueryInstance(): void
+    {
+        parent::testQueryInstance();
+
+        $this->assertInstanceOf(PostgresUpsertQuery::class, $this->database->upsert());
+    }
+}

--- a/tests/Database/Functional/Driver/SQLServer/Query/UpsertQueryTest.php
+++ b/tests/Database/Functional/Driver/SQLServer/Query/UpsertQueryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\SQLServer\Query;
+
+// phpcs:ignore
+use Cycle\Database\Driver\SQLServer\Query\SQLServerUpsertQuery;
+use Cycle\Database\Exception\CompilerException;
+use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+final class UpsertQueryTest extends BaseTest
+{
+    public const DRIVER = 'sqlserver';
+
+    public function testQueryInstance(): void
+    {
+        $this->assertInstanceOf(SQLServerUpsertQuery::class, $this->database->upsert());
+        $this->assertInstanceOf(SQLServerUpsertQuery::class, $this->database->table->upsert());
+    }
+
+    public function testCompileUpsertQueryThrowsException(): void
+    {
+        $this->expectException(CompilerException::class);
+        $this->expectExceptionMessage('Upsert behaviour is not supported by SQLServer');
+
+        $this->db()->upsert('table')->values([])->__toString();
+    }
+}

--- a/tests/Database/Functional/Driver/SQLServer/Query/UpsertQueryTest.php
+++ b/tests/Database/Functional/Driver/SQLServer/Query/UpsertQueryTest.php
@@ -5,29 +5,20 @@ declare(strict_types=1);
 namespace Cycle\Database\Tests\Functional\Driver\SQLServer\Query;
 
 // phpcs:ignore
-use Cycle\Database\Driver\SQLServer\Query\SQLServerUpsertQuery;
-use Cycle\Database\Exception\CompilerException;
-use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\Database\Tests\Functional\Driver\Common\Query\UpsertQueryTest as CommonClass;
 
 /**
  * @group driver
  * @group driver-sqlserver
  */
-final class UpsertQueryTest extends BaseTest
+final class UpsertQueryTest extends CommonClass
 {
     public const DRIVER = 'sqlserver';
-
-    public function testQueryInstance(): void
-    {
-        $this->assertInstanceOf(SQLServerUpsertQuery::class, $this->database->upsert());
-        $this->assertInstanceOf(SQLServerUpsertQuery::class, $this->database->table->upsert());
-    }
-
-    public function testCompileUpsertQueryThrowsException(): void
-    {
-        $this->expectException(CompilerException::class);
-        $this->expectExceptionMessage('Upsert behaviour is not supported by SQLServer');
-
-        $this->db()->upsert('table')->values([])->__toString();
-    }
+    protected const QUERY_REQUIRES_CONFLICTS   = false;
+    protected const QUERY_WITH_VALUES          = 'MERGE INTO [table] WITH (holdlock) AS [target] USING ( VALUES (?, ?) ) AS [source] ([email], [name]) ON [target].[email] = [source].[email] WHEN MATCHED THEN UPDATE SET [target].[email] = [source].[email], [target].[name] = [source].[name] WHEN NOT MATCHED THEN INSERT ([email], [name]) VALUES ([source].[email], [source].[name])';
+    protected const QUERY_WITH_STATES_VALUES   = 'MERGE INTO [table] WITH (holdlock) AS [target] USING ( VALUES (?, ?) ) AS [source] ([email], [name]) ON [target].[email] = [source].[email] WHEN MATCHED THEN UPDATE SET [target].[email] = [source].[email], [target].[name] = [source].[name] WHEN NOT MATCHED THEN INSERT ([email], [name]) VALUES ([source].[email], [source].[name])';
+    protected const QUERY_WITH_MULTIPLE_ROWS   = 'MERGE INTO [table] WITH (holdlock) AS [target] USING ( VALUES (?, ?), (?, ?) ) AS [source] ([email], [name]) ON [target].[email] = [source].[email] WHEN MATCHED THEN UPDATE SET [target].[email] = [source].[email], [target].[name] = [source].[name] WHEN NOT MATCHED THEN INSERT ([email], [name]) VALUES ([source].[email], [source].[name])';
+    protected const QUERY_WITH_EXPRESSIONS     = 'MERGE INTO [table] WITH (holdlock) AS [target] USING ( VALUES (?, ?, NOW(), NOW(), ?) ) AS [source] ([email], [name], [created_at], [updated_at], [deleted_at]) ON [target].[email] = [source].[email] WHEN MATCHED THEN UPDATE SET [target].[email] = [source].[email], [target].[name] = [source].[name], [target].[created_at] = [source].[created_at], [target].[updated_at] = [source].[updated_at], [target].[deleted_at] = [source].[deleted_at] WHEN NOT MATCHED THEN INSERT ([email], [name], [created_at], [updated_at], [deleted_at]) VALUES ([source].[email], [source].[name], [source].[created_at], [source].[updated_at], [source].[deleted_at])';
+    protected const QUERY_WITH_FRAGMENTS       = 'MERGE INTO [table] WITH (holdlock) AS [target] USING ( VALUES (?, ?, NOW(), datetime(\'now\'), ?) ) AS [source] ([email], [name], [created_at], [updated_at], [deleted_at]) ON [target].[email] = [source].[email] WHEN MATCHED THEN UPDATE SET [target].[email] = [source].[email], [target].[name] = [source].[name], [target].[created_at] = [source].[created_at], [target].[updated_at] = [source].[updated_at], [target].[deleted_at] = [source].[deleted_at] WHEN NOT MATCHED THEN INSERT ([email], [name], [created_at], [updated_at], [deleted_at]) VALUES ([source].[email], [source].[name], [source].[created_at], [source].[updated_at], [source].[deleted_at])';
+    protected const QUERY_WITH_CUSTOM_FRAGMENT = 'MERGE INTO [table] WITH (holdlock) AS [target] USING ( VALUES (?, ?, NOW()) ) AS [source] ([email], [name], [expired_at]) ON [target].[email] = [source].[email] WHEN MATCHED THEN UPDATE SET [target].[email] = [source].[email], [target].[name] = [source].[name], [target].[expired_at] = [source].[expired_at] WHEN NOT MATCHED THEN INSERT ([email], [name], [expired_at]) VALUES ([source].[email], [source].[name], [source].[expired_at])';
 }

--- a/tests/Database/Functional/Driver/SQLite/Query/UpsertQueryTest.php
+++ b/tests/Database/Functional/Driver/SQLite/Query/UpsertQueryTest.php
@@ -14,5 +14,4 @@ use Cycle\Database\Tests\Functional\Driver\Common\Query\UpsertQueryTest as Commo
 class UpsertQueryTest extends CommonClass
 {
     public const DRIVER = 'sqlite';
-    public const UPSERT_CLAUSE = 'ON CONFLICT DO UPDATE SET';
 }

--- a/tests/Database/Functional/Driver/SQLite/Query/UpsertQueryTest.php
+++ b/tests/Database/Functional/Driver/SQLite/Query/UpsertQueryTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\SQLite\Query;
+
+// phpcs:ignore
+use Cycle\Database\Tests\Functional\Driver\Common\Query\UpsertQueryTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class UpsertQueryTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+    public const UPSERT_CLAUSE = 'ON CONFLICT DO UPDATE SET';
+}


### PR DESCRIPTION
This pull request adds support for performing `upsert` queries. Ticket [#50](https://github.com/cycle/database/issues/50) is what sparked interest for this feature.

## 🔍 What was changed

* Each driver (MySQL, Postgres, SQLite and SQLServer) compiler supports an UpsertQuery.
* Differences between SQL dialects have been accounted for.

## 🤔 Why?

1. Upsert allows developers to combine insert and update operations into a single command, reducing the need for explicit existence checks and multiple database calls.
2. Modern databases support atomic upsert operations, which help maintain data integrity even in concurrent environments.
3. Upsert reduces the number of database round-trips, eliminating separate existence checks followed by insert or update, likely leading to better performance, especially in high-volume scenarios.

## 📝 Checklist

- Closes #50
- How was this tested:
    - [x] Unit tests added

## 📃 Documentation

Note that specifying conflict index column names is redundant and not required for `MySQL`.

### PHP

```php
$upsert = $this->database->upsert('users')
    ->conflicts('email')
    ->columns('email', 'name')
    ->values('adam@email.com', 'Adam')
    ->values('bill@email.com', 'Bill');
```

```php
$upsert = $this->database->upsert('users')
    ->conflicts(['email'])
    ->values([
        ['email' => 'adam@email.com', 'name' => 'Adam'],
        ['email' => 'bill@email.com', 'name' => 'Bill'],
    ]);
```

### MyQL

```sql
INSERT INTO `users` (`email`, `name`)
VALUES
    ('adam@email.com', 'Adam'),
    ('bill@email.com', 'Bill')
ON DUPLICATE KEY UPDATE
    `email` = VALUES(`email`),
    `name` = VALUES(`name`);
```

### Postgres / SQLite

```sql
INSERT INTO `users` (`email`, `name`)
VALUES
    ('adam@email.com', 'Adam'),
    ('bill@email.com', 'Bill')
ON CONFLICT (`email`) DO UPDATE SET
    `email` = EXCLUDED.`email`,
    `name` = EXCLUDED.`name`
```

### MSSQL

```sql
MERGE INTO [users] WITH (holdlock) AS [target] 
USING ( VALUES 
    ('adam@email.com', 'Adam'),
    ('bill@email.com', 'Bill') 
) AS [source] ([email], [name]) 
ON [target].[email] = [source].[email] 
WHEN MATCHED THEN 
    UPDATE SET 
        [target].[email] = [source].[email], 
        [target].[name] = [source].[name] 
WHEN NOT MATCHED THEN 
    INSERT ([email], [name]) 
    VALUES ([source].[email], [source].[name])
```