### PR TITLE
feat: Add `wrapWhere` method to group existing WHERE conditions

### DIFF
--- a/src/Query/Traits/WhereTrait.php
+++ b/src/Query/Traits/WhereTrait.php
@@ -147,6 +147,38 @@ trait WhereTrait
     }
 
     /**
+     * Wrap all currently registered WHERE tokens into a single nested AND-group.
+     *
+     * After the call, the WHERE state holds exactly one top-level token — a nested
+     * group containing everything added before. Subsequent `where/orWhere/...` calls
+     * append at the top level, alongside this group:
+     *
+     *     $q->where('a', 1)->orWhere('a', 2)->wrapWhere()->where('b', 3);
+     *     // WHERE (a = 1 OR a = 2) AND b = 3
+     *
+     * No-op when no where tokens have been registered yet.
+     *
+     * Typical use case: ORM scopes that must stay protected from a later `orWhere`
+     * added by user code.
+     *
+     * @return $this|self
+     */
+    public function wrapWhere(): self
+    {
+        if ($this->whereTokens === []) {
+            return $this;
+        }
+
+        $this->whereTokens = [
+            ['AND', '('],
+            ...$this->whereTokens,
+            ['', ')'],
+        ];
+
+        return $this;
+    }
+
+    /**
      * Convert various amount of where function arguments into valid where token.
      *
      * @param array $params Set of parameters collected from where functions.

--- a/tests/Database/Functional/Driver/Common/Query/SelectQueryTest.php
+++ b/tests/Database/Functional/Driver/Common/Query/SelectQueryTest.php
@@ -2565,6 +2565,251 @@ WHERE {name} = \'Antony\' AND {id} IN (SELECT{id}FROM {other}WHERE {x} = 123)',
         );
     }
 
+    public function testWrapWhereGroupsExistingConditions(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from(['users'])
+            ->where('name', 'Anton')
+            ->orWhere('name', 'John')
+            ->wrapWhere()
+            ->where('active', true);
+
+        $this->assertSameQuery(
+            'SELECT * FROM {users} WHERE ({name} = ? OR {name} = ?) AND {active} = ?',
+            $select,
+        );
+    }
+
+    public function testWrapWhereProtectsScopeFromLaterOrWhere(): void
+    {
+        // Models a soft-delete-style scope: condition added first, then wrapped,
+        // then a user-supplied orWhere — without wrapWhere the scope would be lost.
+        $select = $this->database
+            ->select()
+            ->from(['users'])
+            ->where('deleted_at', null)
+            ->wrapWhere()
+            ->orWhere('id', 5);
+
+        $this->assertSameQuery(
+            'SELECT * FROM {users} WHERE ({deleted_at} IS NULL) OR {id} = ?',
+            $select,
+        );
+    }
+
+    public function testWrapWhereOnEmptyWhereIsNoop(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from(['users'])
+            ->wrapWhere()
+            ->where('active', true);
+
+        $this->assertSameQuery(
+            'SELECT * FROM {users} WHERE {active} = ?',
+            $select,
+        );
+    }
+
+    public function testWrapWhereWithMultipleAndConditions(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from(['users'])
+            ->where('a', 1)
+            ->where('b', 2)
+            ->where('c', 3)
+            ->wrapWhere()
+            ->where('d', 4);
+
+        $this->assertSameQuery(
+            'SELECT * FROM {users} WHERE ({a} = ? AND {b} = ? AND {c} = ?) AND {d} = ?',
+            $select,
+        );
+    }
+
+    public function testWrapWhereWithMixedAndOrChain(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from(['users'])
+            ->where('a', 1)
+            ->andWhere('b', 2)
+            ->orWhere('c', 3)
+            ->wrapWhere()
+            ->where('d', 4);
+
+        $this->assertSameQuery(
+            'SELECT * FROM {users} WHERE ({a} = ? AND {b} = ? OR {c} = ?) AND {d} = ?',
+            $select,
+        );
+    }
+
+    public function testWrapWhereWithWhereNot(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from(['users'])
+            ->whereNot('status', 'blocked')
+            ->orWhere('role', 'admin')
+            ->wrapWhere()
+            ->where('active', true);
+
+        $this->assertSameQuery(
+            'SELECT * FROM {users} WHERE (NOT {status} = ? OR {role} = ?) AND {active} = ?',
+            $select,
+        );
+    }
+
+    public function testWrapWhereAroundClosureGroup(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from(['users'])
+            ->where(static function (SelectQuery $q): void {
+                $q->where('a', 1)->orWhere('b', 2);
+            })
+            ->wrapWhere()
+            ->where('c', 3);
+
+        $this->assertSameQuery(
+            'SELECT * FROM {users} WHERE (({a} = ? OR {b} = ?)) AND {c} = ?',
+            $select,
+        );
+    }
+
+    public function testClosureGroupAddedAfterWrapWhere(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from(['users'])
+            ->where('a', 1)
+            ->orWhere('b', 2)
+            ->wrapWhere()
+            ->andWhere(static function (SelectQuery $q): void {
+                $q->where('c', 3)->orWhere('d', 4);
+            });
+
+        $this->assertSameQuery(
+            'SELECT * FROM {users} WHERE ({a} = ? OR {b} = ?) AND ({c} = ? OR {d} = ?)',
+            $select,
+        );
+    }
+
+    public function testWrapWhereCalledTwiceInARowIsIdempotentForSql(): void
+    {
+        // Double-wrap adds a redundant pair of parens but is semantically harmless.
+        $select = $this->database
+            ->select()
+            ->from(['users'])
+            ->where('a', 1)
+            ->orWhere('b', 2)
+            ->wrapWhere()
+            ->wrapWhere()
+            ->where('c', 3);
+
+        $this->assertSameQuery(
+            'SELECT * FROM {users} WHERE (({a} = ? OR {b} = ?)) AND {c} = ?',
+            $select,
+        );
+    }
+
+    public function testWrapWhereStackedScopes(): void
+    {
+        // Models multiple stacked ORM scopes: each scope wraps the current state and
+        // appends its own AND-condition. Final SQL should always be logically equivalent
+        // to `user AND s1 AND s2`, with each layer isolated by parentheses.
+        $select = $this->database
+            ->select()
+            ->from(['users'])
+            ->where('a', 1)
+            ->orWhere('a', 2)
+            // first scope
+            ->wrapWhere()
+            ->where('s1', 'x')
+            // second scope
+            ->wrapWhere()
+            ->where('s2', 'y');
+
+        $this->assertSameQuery(
+            'SELECT * FROM {users} WHERE (({a} = ? OR {a} = ?) AND {s1} = ?) AND {s2} = ?',
+            $select,
+        );
+    }
+
+    public function testWrapWhereThenOrWhereNot(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from(['users'])
+            ->where('a', 1)
+            ->andWhere('b', 2)
+            ->wrapWhere()
+            ->orWhereNot('c', 3);
+
+        $this->assertSameQuery(
+            'SELECT * FROM {users} WHERE ({a} = ? AND {b} = ?) OR NOT {c} = ?',
+            $select,
+        );
+    }
+
+    public function testWrapWhereWithArraySyntaxAndOrToken(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from(['users'])
+            ->where([
+                'name' => 'John',
+                '@or' => [
+                    ['status' => 'active'],
+                    ['role' => 'admin'],
+                ],
+            ])
+            ->wrapWhere()
+            ->where('deleted_at', null);
+
+        $this->assertSameQuery(
+            'SELECT * FROM {users} WHERE (({name} = ? AND ({status} = ? OR {role} = ?))) AND {deleted_at} IS NULL',
+            $select,
+        );
+    }
+
+    public function testWrapWhereWithBetweenAndInOperators(): void
+    {
+        $select = $this->database
+            ->select()
+            ->from(['users'])
+            ->where('age', 'between', 18, 65)
+            ->orWhere('role', 'IN', new Parameter(['admin', 'editor']))
+            ->wrapWhere()
+            ->where('active', true);
+
+        $this->assertSameQuery(
+            'SELECT * FROM {users} WHERE ({age} BETWEEN ? AND ? OR {role} IN (?, ?)) AND {active} = ?',
+            $select,
+        );
+    }
+
+    public function testWrapWhereWithLeadingOrWhere(): void
+    {
+        // Edge case: chain starts with orWhere — the leading boolean is suppressed by
+        // the compiler when it's the first token, so behavior should be identical to
+        // starting with where().
+        $select = $this->database
+            ->select()
+            ->from(['users'])
+            ->orWhere('a', 1)
+            ->orWhere('b', 2)
+            ->wrapWhere()
+            ->where('c', 3);
+
+        $this->assertSameQuery(
+            'SELECT * FROM {users} WHERE ({a} = ? OR {b} = ?) AND {c} = ?',
+            $select,
+        );
+    }
+
     public function testAndWhereNotWithArrayOr(): void
     {
         $select = $this->database

--- a/tests/Database/Unit/Query/Tokens/SelectQueryTest.php
+++ b/tests/Database/Unit/Query/Tokens/SelectQueryTest.php
@@ -67,4 +67,53 @@ class SelectQueryTest extends TestCase
             $select->getTokens(),
         );
     }
+
+    public function testWrapWhereOnEmptyIsNoop(): void
+    {
+        $select = (new SelectQuery())->from('table');
+        $select->wrapWhere();
+
+        $this->assertSame([], $select->getTokens()['where']);
+    }
+
+    public function testWrapWhereEnclosesExistingTokens(): void
+    {
+        $select = (new SelectQuery())
+            ->from('table')
+            ->where('a', 1)
+            ->orWhere('a', 2)
+            ->wrapWhere()
+            ->where('b', 3);
+
+        $this->assertEquals(
+            [
+                ['AND', '('],
+                ['AND', ['a', '=', new Parameter(1)]],
+                ['OR', ['a', '=', new Parameter(2)]],
+                ['', ')'],
+                ['AND', ['b', '=', new Parameter(3)]],
+            ],
+            $select->getTokens()['where'],
+        );
+    }
+
+    public function testWrapWhereProtectsAgainstLaterOrWhere(): void
+    {
+        // Simulates a scope condition guarded by wrapWhere against a later user `orWhere`.
+        $select = (new SelectQuery())
+            ->from('table')
+            ->where('deleted_at', null)
+            ->wrapWhere()
+            ->orWhere('id', 5);
+
+        $this->assertEquals(
+            [
+                ['AND', '('],
+                ['AND', ['deleted_at', '=', new Parameter(null)]],
+                ['', ')'],
+                ['OR', ['id', '=', new Parameter(5)]],
+            ],
+            $select->getTokens()['where'],
+        );
+    }
 }


### PR DESCRIPTION
<!-- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

## 🔍 What was changed

Added `wrapWhere()` to `WhereTrait`. The method collapses all currently-registered `WHERE` tokens into a single nested AND-group, leaving the where state with exactly one top-level token — the enclosing group. Subsequent `where()/andWhere()/orWhere()/...` calls append at the top level **alongside** that group, no longer inside it.

```php
$select
    ->where('a', 1)
    ->orWhere('a', 2)
    ->wrapWhere()      // freeze what came before into a group
    ->where('b', 3);
// WHERE (a = 1 OR a = 2) AND b = 3
```

Behavior:

- **No-op on empty where state** — calling `wrapWhere()` before any condition is registered does nothing.
- **Idempotent for SQL semantics** — repeated calls only add a redundant pair of parentheses; the resulting predicate is logically identical.
- **Order-preserving** — internal token order and operators (`AND`, `OR`, `NOT`, `BETWEEN`, `IN`, closure groups, `@or`/`@and` array sugar) are kept as-is inside the new group.

> [!NOTE]
> The method is a low-level primitive intended for use by ORM scope mechanisms (and any other code that needs to defensively enclose its conditions). It is safe to expose publicly but is not the canonical way to build a nested WHERE — for that, keep using `where(function ($q) { ... })`.

## 🤔 Why?

Today an ORM scope (e.g. `SoftDeleteScope`) adds its conditions at the **top level** of the WHERE clause. As soon as user code attaches `orWhere(...)` later, the scope and the user predicate join the same flat boolean chain:

```sql
WHERE deleted_at IS NULL OR id = 5
-- ^^ scope is silently bypassed
```

There was no way for a scope to enclose itself (or the user's prior conditions) in parentheses without a heavier rework — the only existing nesting primitive is the closure form of `where()`, which can only group conditions *being added now*, not conditions already registered.

`wrapWhere()` fills exactly that gap. With it, a scope's `apply()` can do:

```php
public function apply(QueryBuilder $q): void
{
    $q->wrapWhere();                // protect anything already registered
    $q->where('deleted_at', null);  // add scope condition at the top level
}
```

producing

```sql
WHERE (user_conditions...) AND deleted_at IS NULL
```

This unlocks an isolation pattern for stacked scopes (e.g. `SoftDelete` + multi-tenancy + role visibility) without introducing a new scope interface, without changing `ScopeInterface::apply()`, and without touching the `SelectQuery` build pipeline — see the companion change in `cycle/orm`.

## 📝 Checklist

- Closes #<!-- add issue number here -->
- How was this tested:
  - [x] Tested manually
  - [x] Unit tests added

Tests cover:

- Token-level structure (3 unit tests in `Tests/Unit/Query/Tokens/SelectQueryTest`): no-op on empty state, exact token layout after wrapping a mixed AND/OR chain, scope-protection scenario.
- SQL output across a range of combinations (11 new functional tests, inherited by every driver from `Common/Query/SelectQueryTest`): plain AND chain, mixed AND/OR, `whereNot`, wrapping an already-closure-nested group, attaching a closure group **after** `wrapWhere()`, double `wrapWhere()`, stacked scope emulation (two layers), `orWhereNot` after wrap, array syntax with `@or`, `BETWEEN`/`IN` operators, and a chain that starts with `orWhere`.

Full SQLite functional suite: 662 tests, no regressions.

## 📃 Documentation

Inline phpdoc on `WhereTrait::wrapWhere()` with a worked example and a description of the typical use case (scope isolation). No separate doc page is required for a single primitive; the consumer-facing documentation will live in the ORM-side PR that wires this into the scope mechanism.
