### PR TITLE
fix(SelectQuery): process the last partial chunk in runChunks()

### DIFF
--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -305,7 +305,7 @@ class SelectQuery extends ActiveQuery implements
         $select->limit($limit);
 
         $offset = 0;
-        while ($offset + $limit <= $count) {
+        while ($offset < $count) {
             $result = $callback(
                 $select->offset($offset)->getIterator(),
                 $offset,

--- a/tests/Database/Functional/Driver/Common/Driver/StatementTest.php
+++ b/tests/Database/Functional/Driver/Common/Driver/StatementTest.php
@@ -313,6 +313,69 @@ abstract class StatementTest extends BaseTest
         $this->assertSame(\range(1, 10), $visited);
     }
 
+    public function testChunksWithLimitGreaterThanCount(): void
+    {
+        $table = $this->database->table('sample_table');
+        $this->fillData();
+
+        $select = $table->select();
+
+        // chunk size larger than the total row count must still yield every row in a single chunk
+        $visited = [];
+        $chunks = 0;
+        $select->runChunks(
+            100,
+            function (StatementInterface $result) use (&$visited, &$chunks): void {
+                $chunks++;
+                foreach ($result as $row) {
+                    $visited[] = $row['id'];
+                }
+            },
+        );
+
+        $this->assertSame(1, $chunks);
+        $this->assertSame(\range(1, 10), $visited);
+    }
+
+    public function testChunksOnEmptyResultNeverInvokesCallback(): void
+    {
+        $table = $this->database->table('sample_table');
+        // no data inserted
+
+        $select = $table->select();
+
+        $invoked = false;
+        $select->runChunks(
+            5,
+            function () use (&$invoked): void {
+                $invoked = true;
+            },
+        );
+
+        $this->assertFalse($invoked);
+    }
+
+    public function testChunksPassOffsetAndCountToCallback(): void
+    {
+        $table = $this->database->table('sample_table');
+        $this->fillData();
+
+        $select = $table->select();
+
+        $offsets = [];
+        $counts = [];
+        $select->runChunks(
+            3,
+            function (StatementInterface $result, int $offset, int $count) use (&$offsets, &$counts): void {
+                $offsets[] = $offset;
+                $counts[] = $count;
+            },
+        );
+
+        $this->assertSame([0, 3, 6, 9], $offsets);
+        $this->assertSame([10, 10, 10, 10], $counts);
+    }
+
     public function testNativeParameters(): void
     {
         $this->fillData();

--- a/tests/Database/Functional/Driver/Common/Driver/StatementTest.php
+++ b/tests/Database/Functional/Driver/Common/Driver/StatementTest.php
@@ -292,6 +292,27 @@ abstract class StatementTest extends BaseTest
         $this->assertSame(5, $count);
     }
 
+    public function testChunksProcessLastPartialChunk(): void
+    {
+        $table = $this->database->table('sample_table');
+        $this->fillData();
+
+        $select = $table->select();
+
+        // 10 rows split by chunks of 3: the last chunk holds the single remaining row (10 % 3 == 1)
+        $visited = [];
+        $select->runChunks(
+            3,
+            function (StatementInterface $result) use (&$visited): void {
+                foreach ($result as $row) {
+                    $visited[] = $row['id'];
+                }
+            },
+        );
+
+        $this->assertSame(\range(1, 10), $visited);
+    }
+
     public function testNativeParameters(): void
     {
         $this->fillData();

--- a/tests/Database/Functional/Driver/Common/Driver/StatementTest.php
+++ b/tests/Database/Functional/Driver/Common/Driver/StatementTest.php
@@ -297,7 +297,7 @@ abstract class StatementTest extends BaseTest
         $table = $this->database->table('sample_table');
         $this->fillData();
 
-        $select = $table->select();
+        $select = $table->select()->orderBy('id');
 
         // 10 rows split by chunks of 3: the last chunk holds the single remaining row (10 % 3 == 1)
         $visited = [];
@@ -310,7 +310,7 @@ abstract class StatementTest extends BaseTest
             },
         );
 
-        $this->assertSame(\range(1, 10), $visited);
+        $this->assertEquals(\range(1, 10), $visited);
     }
 
     public function testChunksWithLimitGreaterThanCount(): void
@@ -318,7 +318,7 @@ abstract class StatementTest extends BaseTest
         $table = $this->database->table('sample_table');
         $this->fillData();
 
-        $select = $table->select();
+        $select = $table->select()->orderBy('id');
 
         // chunk size larger than the total row count must still yield every row in a single chunk
         $visited = [];
@@ -334,7 +334,7 @@ abstract class StatementTest extends BaseTest
         );
 
         $this->assertSame(1, $chunks);
-        $this->assertSame(\range(1, 10), $visited);
+        $this->assertEquals(\range(1, 10), $visited);
     }
 
     public function testChunksOnEmptyResultNeverInvokesCallback(): void


### PR DESCRIPTION
## 🔍 What was changed

`SelectQuery::runChunks()` no longer skips the last partial chunk.

The loop guard was `$offset + $limit <= $count`, which required a **full** remaining chunk and stopped as soon as fewer than `$limit` rows were left. The trailing partial page (`$count % $limit` rows) was silently dropped — no error, no warning. The guard is changed to `$offset < $count`, so the final iteration issues `LIMIT N OFFSET k` and naturally returns the remaining `< $limit` rows.

> [!NOTE]
> The same guard also broke the `limit > count` case entirely: a table with fewer rows than the chunk size processed **zero** rows. This is fixed by the same change and covered by a dedicated test.

## 🤔 Why?

Silent data loss in any batch/export/migration built on `runChunks()`. Full coverage previously happened only when `$count` was an exact multiple of `$limit`.

Example — 2500 rows, `runChunks(1000, …)`:

```
offset=0     0+1000 <= 2500  ✓  → rows 0…999
offset=1000  1000+1000<=2500 ✓  → rows 1000…1999
offset=2000  2000+1000<=2500 ✗  → STOP
                                  rows 2000…2499  NEVER processed
```

## 📝 Checklist

- Closes #254
- How was this tested:
  - [ ] Tested manually
  - [x] Unit tests added

  Added regression and edge-case tests to `StatementTest` (common across all drivers):
  - `testChunksProcessLastPartialChunk` — trailing partial page is visited (`count % limit != 0`)
  - `testChunksWithLimitGreaterThanCount` — chunk size larger than the row count still yields every row
  - `testChunksPassOffsetAndCountToCallback` — `$offset`/`$count` callback arguments
  - `testChunksOnEmptyResultNeverInvokesCallback` — empty result set never invokes the callback

## 📃 Documentation

_Not needed — behavioral bugfix, public API unchanged._
