### PR TITLE
feat(SelectQuery): refine Psalm integer types on query bounds

### DIFF
--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -255,6 +255,9 @@ class SelectQuery extends ActiveQuery implements
         return $this;
     }
 
+    /**
+     * @return int<0, max>|null
+     */
     public function getLimit(): ?int
     {
         return $this->limit;
@@ -271,6 +274,9 @@ class SelectQuery extends ActiveQuery implements
         return $this;
     }
 
+    /**
+     * @return int<0, max>|null
+     */
     public function getOffset(): ?int
     {
         return $this->offset;
@@ -293,6 +299,8 @@ class SelectQuery extends ActiveQuery implements
      * });
      *
      * You must return FALSE from walk function to stop chunking.
+     *
+     * @param int<1, max> $limit Chunk size.
      *
      * @throws \Throwable
      */
@@ -324,7 +332,9 @@ class SelectQuery extends ActiveQuery implements
     /**
      * Count number of rows in query. Limit, offset, order by, group by values will be ignored.
      *
-     * @psalm-param non-empty-string $column Column to count by (every column by default).
+     * @param non-empty-string $column Column to count by (every column by default).
+     *
+     * @return int<0, max>
      */
     public function count(string $column = '*', bool $distinct = false): int
     {
@@ -346,7 +356,7 @@ class SelectQuery extends ActiveQuery implements
     }
 
     /**
-     * @psalm-param non-empty-string $column
+     * @param non-empty-string $column
      */
     public function avg(string $column): mixed
     {
@@ -354,7 +364,7 @@ class SelectQuery extends ActiveQuery implements
     }
 
     /**
-     * @psalm-param non-empty-string $column
+     * @param non-empty-string $column
      */
     public function max(string $column): mixed
     {
@@ -362,7 +372,7 @@ class SelectQuery extends ActiveQuery implements
     }
 
     /**
-     * @psalm-param non-empty-string $column
+     * @param non-empty-string $column
      */
     public function min(string $column): mixed
     {
@@ -370,7 +380,7 @@ class SelectQuery extends ActiveQuery implements
     }
 
     /**
-     * @psalm-param non-empty-string $column
+     * @param non-empty-string $column
      */
     public function sum(string $column): mixed
     {
@@ -436,8 +446,8 @@ class SelectQuery extends ActiveQuery implements
     }
 
     /**
-     * @psalm-param non-empty-string $method
-     * @psalm-param non-empty-string $column
+     * @param non-empty-string $method
+     * @param non-empty-string $column
      */
     private function runAggregate(string $method, string $column): mixed
     {


### PR DESCRIPTION
## 🔍 What was changed

Refined the Psalm types in `SelectQuery` so numeric bounds and string constraints are expressed at the type level.

**Added integer bounds:**

| Method | Annotation | Meaning |
| ------ | ---------- | ------- |
| `runChunks()` | `@param int<1, max> $limit` | Chunk size must be positive — a non-positive value never advances the offset and would spin in an endless loop. |
| `getLimit()` | `@return int<0, max>\|null` | Limit is `>= 0` or `null` (`0` disables limiting). |
| `getOffset()` | `@return int<0, max>\|null` | Offset is `>= 0` or `null`. |
| `count()` | `@return int<0, max>` | A row count is never negative. |

**Simplified existing hints:** dropped the redundant `psalm-` prefix from the `non-empty-string` column/method hints on `count()`, `avg()`, `max()`, `min()`, `sum()` and `runAggregate()` — plain `@param` advanced types are now broadly supported (Psalm, PHPStan, PhpStorm).

> [!NOTE]
> Annotation-only — runtime behaviour and public signatures are unchanged.

## 🤔 Why?

Expressing these bounds as Psalm types lets static analysis catch invalid values **at the call site** instead of failing (or hanging) at runtime, and gives consumers more precise return types. The endless-loop risk on a non-positive chunk size was surfaced by the Copilot review on #255.

Setter params (`limit()` / `offset()`) are intentionally left as-is: narrowing them would break the `Spiral\Pagination\PaginableInterface` contract (`MoreSpecificImplementedParamType`). The return-type refinements are safe because `LessSpecificReturnStatement` / `MoreSpecificReturnType` are already suppressed project-wide in `psalm.xml`.

## 📝 Checklist

- How was this tested:
  - [x] Tested manually
  - [ ] Unit tests added

  Verified with `psalm` (no new issues introduced) and `php-cs-fixer` (clean). No unit tests are added — these are static-analysis annotations with no runtime effect.

## 📃 Documentation

_Not needed — type-level annotations, public API signatures unchanged._
