### PR TITLE
perf(Schema): batch table introspection queries

### DIFF
--- a/src/Driver/MySQL/Schema/MySQLTable.php
+++ b/src/Driver/MySQL/Schema/MySQLTable.php
@@ -39,6 +39,12 @@ class MySQLTable extends AbstractTable
     private ?string $version = null;
 
     /**
+     * Memoized `SHOW INDEXES` result, shared between {@see fetchIndexes()} and
+     * {@see fetchPrimaryKeys()}.
+     */
+    private ?array $indexRows = null;
+
+    /**
      * Change table engine. Such operation will be applied only at moment of table creation.
      *
      * @psalm-param non-empty-string $engine
@@ -67,6 +73,7 @@ class MySQLTable extends AbstractTable
     /**
      * Populate table schema with values from database.
      */
+    #[\Override]
     protected function initSchema(State $state): void
     {
         parent::initSchema($state);
@@ -80,6 +87,7 @@ class MySQLTable extends AbstractTable
         )->fetch()['Engine'];
     }
 
+    #[\Override]
     protected function isIndexColumnSortingSupported(): bool
     {
         if (!$this->version) {
@@ -93,6 +101,7 @@ class MySQLTable extends AbstractTable
         return \version_compare($this->version, '8.0', '>=');
     }
 
+    #[\Override]
     protected function fetchColumns(): array
     {
         $query = "SHOW FULL COLUMNS FROM {$this->driver->identifier($this->getFullName())}";
@@ -109,13 +118,18 @@ class MySQLTable extends AbstractTable
         return $result;
     }
 
+    #[\Override]
+    protected function resetIntrospectionCache(): void
+    {
+        $this->indexRows = null;
+    }
+
+    #[\Override]
     protected function fetchIndexes(): array
     {
-        $query = "SHOW INDEXES FROM {$this->driver->identifier($this->getFullName())}";
-
         //Gluing all index definitions together
         $schemas = [];
-        foreach ($this->driver->query($query) as $index) {
+        foreach ($this->indexRows() as $index) {
             if ($index['Key_name'] === 'PRIMARY') {
                 //Skipping PRIMARY index
                 continue;
@@ -132,26 +146,38 @@ class MySQLTable extends AbstractTable
         return $result;
     }
 
+    #[\Override]
     protected function fetchReferences(): array
     {
         $references = $this->driver->query(
             'SELECT * FROM `information_schema`.`referential_constraints`
             WHERE `constraint_schema` = ? AND `table_name` = ?',
             [$this->driver->getSource(), $this->getFullName()],
+        )->fetchAll();
+
+        if ($references === []) {
+            return [];
+        }
+
+        // `key_column_usage` is an expensive view, it must not be queried per constraint.
+        $usage = [];
+        $rows = $this->driver->query(
+            'SELECT * FROM `information_schema`.`key_column_usage`
+            WHERE `table_schema` = ? AND `table_name` = ? AND `referenced_table_name` IS NOT NULL
+            ORDER BY `constraint_name`, `ordinal_position`',
+            [$this->driver->getSource(), $this->getFullName()],
         );
+
+        foreach ($rows as $row) {
+            $usage[$row['CONSTRAINT_NAME']][] = $row;
+        }
 
         $result = [];
         foreach ($references as $schema) {
-            $columns = $this->driver->query(
-                'SELECT * FROM `information_schema`.`key_column_usage`
-                WHERE `constraint_name` = ? AND `table_schema` = ? AND `table_name` = ?',
-                [$schema['CONSTRAINT_NAME'], $this->driver->getSource(), $this->getFullName()],
-            )->fetchAll();
-
             $schema['COLUMN_NAME'] = [];
             $schema['REFERENCED_COLUMN_NAME'] = [];
 
-            foreach ($columns as $column) {
+            foreach ($usage[$schema['CONSTRAINT_NAME']] ?? [] as $column) {
                 $schema['COLUMN_NAME'][] = $column['COLUMN_NAME'];
                 $schema['REFERENCED_COLUMN_NAME'][] = $column['REFERENCED_COLUMN_NAME'];
             }
@@ -169,12 +195,11 @@ class MySQLTable extends AbstractTable
     /**
      * Fetching primary keys from table.
      */
+    #[\Override]
     protected function fetchPrimaryKeys(): array
     {
-        $query = "SHOW INDEXES FROM {$this->driver->identifier($this->getFullName())}";
-
         $primaryKeys = [];
-        foreach ($this->driver->query($query) as $index) {
+        foreach ($this->indexRows() as $index) {
             if ($index['Key_name'] === 'PRIMARY') {
                 $primaryKeys[] = $index['Column_name'];
             }
@@ -186,6 +211,7 @@ class MySQLTable extends AbstractTable
     /**
      * @psalm-param non-empty-string $name
      */
+    #[\Override]
     protected function createColumn(string $name): AbstractColumn
     {
         return new MySQLColumn($this->getFullName(), $name, $this->driver->getTimezone());
@@ -194,6 +220,7 @@ class MySQLTable extends AbstractTable
     /**
      * @psalm-param non-empty-string $name
      */
+    #[\Override]
     protected function createIndex(string $name): AbstractIndex
     {
         return new MySQLIndex($this->getFullName(), $name);
@@ -202,8 +229,20 @@ class MySQLTable extends AbstractTable
     /**
      * @psalm-param non-empty-string $name
      */
+    #[\Override]
     protected function createForeign(string $name): AbstractForeignKey
     {
         return new MySQLForeignKey($this->getFullName(), $this->getPrefix(), $name);
+    }
+
+    /**
+     * `SHOW INDEXES` carries both the secondary indexes and the primary key, so it is executed once
+     * per introspection and split in PHP.
+     */
+    private function indexRows(): array
+    {
+        return $this->indexRows ??= $this->driver
+            ->query("SHOW INDEXES FROM {$this->driver->identifier($this->getFullName())}")
+            ->fetchAll();
     }
 }

--- a/src/Driver/Postgres/Schema/PostgresColumn.php
+++ b/src/Driver/Postgres/Schema/PostgresColumn.php
@@ -305,12 +305,20 @@ class PostgresColumn extends AbstractColumn
 
     /**
      * @param DriverInterface $driver Postgres columns are bit more complex.
+     * @param array|null $checkConstraints Pre-fetched CHECK constraints of the whole table keyed by
+     *        the textual `conkey` value. When `null` the constraints are resolved with a dedicated
+     *        query (requires `tableOID` in the `$schema`).
+     * @param array|null $enumValues Pre-fetched native enum ranges keyed as `<schema>.<type>`.
+     *        When `null` the range is resolved with a dedicated query.
+     *
      * @psalm-param non-empty-string $table Table name.
      */
     public static function createInstance(
         string $table,
         array $schema,
         DriverInterface $driver,
+        ?array $checkConstraints = null,
+        ?array $enumValues = null,
     ): self {
         $column = new self($table, $schema['column_name'], $driver->getTimezone());
 
@@ -365,7 +373,7 @@ class PostgresColumn extends AbstractColumn
              * Attention, this is not default enum type emulated via CHECK.
              * This is real Postgres enum type.
              */
-            self::resolveEnum($driver, $column);
+            self::resolveEnum($driver, $schema, $column, $enumValues);
         }
 
         if ($column->type === 'timestamp' || $column->type === 'time' || $column->type === 'interval') {
@@ -382,7 +390,7 @@ class PostgresColumn extends AbstractColumn
 
         if (!empty($column->size) && \str_contains($column->type, 'char')) {
             //Potential enum with manually created constraint (check in)
-            self::resolveConstrains($driver, $schema, $column);
+            self::resolveConstrains($driver, $schema, $column, $checkConstraints);
         }
 
         if ($column->type === 'interval' && \is_string($schema['interval_type'])) {
@@ -404,6 +412,7 @@ class PostgresColumn extends AbstractColumn
         return $column;
     }
 
+    #[\Override]
     public function getConstraints(): array
     {
         $constraints = parent::getConstraints();
@@ -418,6 +427,7 @@ class PostgresColumn extends AbstractColumn
     /**
      * @psalm-return non-empty-string
      */
+    #[\Override]
     public function getAbstractType(): string
     {
         return !empty($this->enumValues) ? 'enum' : parent::getAbstractType();
@@ -459,6 +469,7 @@ class PostgresColumn extends AbstractColumn
         return $this->type('bigPrimary');
     }
 
+    #[\Override]
     public function enum(string|array $values): AbstractColumn
     {
         $this->enumValues = \array_map('strval', \is_array($values) ? $values : \func_get_args());
@@ -487,6 +498,7 @@ class PostgresColumn extends AbstractColumn
     /**
      * @psalm-return non-empty-string
      */
+    #[\Override]
     public function sqlStatement(DriverInterface $driver): string
     {
         $statement = [$driver->identifier($this->name), $this->type];
@@ -626,6 +638,7 @@ class PostgresColumn extends AbstractColumn
         return $operations;
     }
 
+    #[\Override]
     public function compare(AbstractColumn $initial): bool
     {
         if (parent::compare($initial)) {
@@ -638,6 +651,7 @@ class PostgresColumn extends AbstractColumn
         );
     }
 
+    #[\Override]
     public function getComment(): string
     {
         return $this->comment;
@@ -654,6 +668,7 @@ class PostgresColumn extends AbstractColumn
         return "COMMENT ON COLUMN {$tableName}.{$identifier} IS " . $driver->quote($this->comment);
     }
 
+    #[\Override]
     protected static function isJson(AbstractColumn $column): bool
     {
         return $column->getAbstractType() === 'json' || $column->getAbstractType() === 'jsonb';
@@ -662,6 +677,7 @@ class PostgresColumn extends AbstractColumn
     /**
      * @psalm-return non-empty-string
      */
+    #[\Override]
     protected function quoteEnum(DriverInterface $driver): string
     {
         //Postgres enums are just constrained strings
@@ -675,17 +691,24 @@ class PostgresColumn extends AbstractColumn
         DriverInterface $driver,
         array $schema,
         self $column,
+        ?array $checkConstraints = null,
     ): void {
-        $query = "SELECT conname, pg_get_constraintdef(oid) as consrc FROM pg_constraint
-        WHERE conrelid = ? AND contype = 'c' AND conkey = ?";
+        $conkey = '{' . $schema['dtd_identifier'] . '}';
 
-        $constraints = $driver->query(
-            $query,
-            [
-                $schema['tableOID'],
-                '{' . $schema['dtd_identifier'] . '}',
-            ],
-        );
+        if ($checkConstraints !== null) {
+            $constraints = $checkConstraints[$conkey] ?? [];
+        } else {
+            $query = "SELECT conname, pg_get_constraintdef(oid) as consrc FROM pg_constraint
+            WHERE conrelid = ? AND contype = 'c' AND conkey = ?";
+
+            $constraints = $driver->query(
+                $query,
+                [
+                    $schema['tableOID'],
+                    $conkey,
+                ],
+            );
+        }
 
         foreach ($constraints as $constraint) {
             $values = static::parseEnumValues($constraint['consrc']);
@@ -701,11 +724,19 @@ class PostgresColumn extends AbstractColumn
     /**
      * Resolve native ENUM type if presented.
      */
-    private static function resolveEnum(DriverInterface $driver, self $column): void
-    {
-        $range = $driver->query('SELECT enum_range(NULL::' . $column->type . ')')->fetchColumn(0);
+    private static function resolveEnum(
+        DriverInterface $driver,
+        array $schema,
+        self $column,
+        ?array $enumValues = null,
+    ): void {
+        if ($enumValues !== null) {
+            $column->enumValues = $enumValues[$schema['udt_schema'] . '.' . $schema['udt_name']] ?? [];
+        } else {
+            $range = $driver->query('SELECT enum_range(NULL::' . $column->type . ')')->fetchColumn(0);
 
-        $column->enumValues = \explode(',', \substr($range, 1, -1));
+            $column->enumValues = \explode(',', \substr($range, 1, -1));
+        }
 
         if (!empty($column->defaultValue)) {
             //In database: 'value'::enumType

--- a/src/Driver/Postgres/Schema/PostgresTable.php
+++ b/src/Driver/Postgres/Schema/PostgresTable.php
@@ -31,6 +31,12 @@ class PostgresTable extends AbstractTable
     private array $sequences = [];
 
     /**
+     * Memoized result of the index introspection query, shared between {@see fetchIndexes()}
+     * and {@see fetchPrimaryKeys()}.
+     */
+    private ?array $indexRows = null;
+
+    /**
      * Sequence object name usually defined only for primary keys and required by ORM to correctly
      * resolve inserted row id.
      */
@@ -45,6 +51,7 @@ class PostgresTable extends AbstractTable
         return $this->primarySequence;
     }
 
+    #[\Override]
     public function getName(): string
     {
         return $this->removeSchemaFromTableName($this->getFullName());
@@ -53,6 +60,7 @@ class PostgresTable extends AbstractTable
     /**
      * SQLServer will reload schemas after successful save.
      */
+    #[\Override]
     public function save(int $operation = HandlerInterface::DO_ALL, bool $reset = true): void
     {
         parent::save($operation, $reset);
@@ -68,6 +76,7 @@ class PostgresTable extends AbstractTable
         }
     }
 
+    #[\Override]
     public function getDependencies(): array
     {
         $tables = [];
@@ -79,20 +88,16 @@ class PostgresTable extends AbstractTable
         return $tables;
     }
 
+    #[\Override]
+    protected function resetIntrospectionCache(): void
+    {
+        $this->indexRows = null;
+    }
+
+    #[\Override]
     protected function fetchColumns(): array
     {
         [$tableSchema, $tableName] = $this->driver->parseSchemaAndTable($this->getFullName());
-
-        //Required for constraints fetch
-        $tableOID = $this->driver->query(
-            'SELECT pgc.oid
-                FROM pg_class as pgc
-                JOIN pg_namespace as pgn
-                    ON (pgn.oid = pgc.relnamespace)
-                WHERE pgn.nspname = ?
-                AND pgc.relname = ?',
-            [$tableSchema, $tableName],
-        )->fetchColumn();
 
         $query = $this->driver->query(
             'SELECT columns.*, pg_type.*, pg_description.description
@@ -126,8 +131,13 @@ class PostgresTable extends AbstractTable
             [$tableSchema, $tableName],
         )->fetchAll(), 'column_name');
 
+        $schemas = $query->fetchAll();
+
+        $checkConstraints = $this->fetchCheckConstraints($tableSchema, $tableName, $schemas);
+        $enumValues = $this->fetchEnumValues($schemas);
+
         $result = [];
-        foreach ($query->fetchAll() as $schema) {
+        foreach ($schemas as $schema) {
             $name = $schema['column_name'];
             if (
                 \is_string($schema['column_default'])
@@ -145,31 +155,23 @@ class PostgresTable extends AbstractTable
 
             $result[] = PostgresColumn::createInstance(
                 $tableSchema . '.' . $tableName,
-                $schema + ['tableOID' => $tableOID],
+                $schema,
                 $this->driver,
+                $checkConstraints,
+                $enumValues,
             );
         }
 
         return $result;
     }
 
+    #[\Override]
     protected function fetchIndexes(bool $all = false): array
     {
         [$tableSchema, $tableName] = $this->driver->parseSchemaAndTable($this->getFullName());
 
-        $query = <<<SQL
-            SELECT i.indexname, i.indexdef, c.contype
-            FROM pg_indexes i
-            LEFT JOIN pg_namespace ns
-                ON nspname = i.schemaname
-            LEFT JOIN pg_constraint c
-                ON c.conname = i.indexname
-                AND c.connamespace = ns.oid
-            WHERE i.schemaname = ? AND i.tablename = ?
-            SQL;
-
         $result = [];
-        foreach ($this->driver->query($query, [$tableSchema, $tableName]) as $schema) {
+        foreach ($this->indexRows() as $schema) {
             if ($schema['contype'] === 'p') {
                 //Skipping primary keys
                 continue;
@@ -180,6 +182,7 @@ class PostgresTable extends AbstractTable
         return $result;
     }
 
+    #[\Override]
     protected function fetchReferences(): array
     {
         [$tableSchema, $tableName] = $this->driver->parseSchemaAndTable($this->getFullName());
@@ -222,23 +225,16 @@ class PostgresTable extends AbstractTable
         return $result;
     }
 
+    #[\Override]
     protected function fetchPrimaryKeys(): array
     {
         [$tableSchema, $tableName] = $this->driver->parseSchemaAndTable($this->getFullName());
 
-        $query = <<<SQL
-            SELECT i.indexname, i.indexdef, c.contype
-            FROM pg_indexes i
-            INNER JOIN pg_namespace ns
-                ON nspname = i.schemaname
-            INNER JOIN pg_constraint c
-                ON c.conname = i.indexname
-                AND c.connamespace = ns.oid
-            WHERE i.schemaname = ? AND i.tablename = ?
-              AND c.contype = 'p'
-            SQL;
+        foreach ($this->indexRows() as $schema) {
+            if ($schema['contype'] !== 'p') {
+                continue;
+            }
 
-        foreach ($this->driver->query($query, [$tableSchema, $tableName]) as $schema) {
             //To simplify definitions
             $index = PostgresIndex::createInstance($tableSchema . '.' . $tableName, $schema);
 
@@ -260,6 +256,7 @@ class PostgresTable extends AbstractTable
     /**
      * @psalm-param non-empty-string $name
      */
+    #[\Override]
     protected function createColumn(string $name): AbstractColumn
     {
         return new PostgresColumn(
@@ -272,6 +269,7 @@ class PostgresTable extends AbstractTable
     /**
      * @psalm-param non-empty-string $name
      */
+    #[\Override]
     protected function createIndex(string $name): AbstractIndex
     {
         return new PostgresIndex(
@@ -283,6 +281,7 @@ class PostgresTable extends AbstractTable
     /**
      * @psalm-param non-empty-string $name
      */
+    #[\Override]
     protected function createForeign(string $name): AbstractForeignKey
     {
         return new PostgresForeignKey(
@@ -295,6 +294,7 @@ class PostgresTable extends AbstractTable
     /**
      * @psalm-param non-empty-string $name
      */
+    #[\Override]
     protected function prefixTableName(string $name): string
     {
         [$schema, $name] = $this->driver->parseSchemaAndTable($name);
@@ -324,5 +324,126 @@ class PostgresTable extends AbstractTable
         }
 
         return $name;
+    }
+
+    /**
+     * Both {@see fetchIndexes()} and {@see fetchPrimaryKeys()} are based on the same data set,
+     * so it is fetched once and split by the constraint type in PHP.
+     */
+    private function indexRows(): array
+    {
+        if ($this->indexRows !== null) {
+            return $this->indexRows;
+        }
+
+        [$tableSchema, $tableName] = $this->driver->parseSchemaAndTable($this->getFullName());
+
+        $query = <<<SQL
+            SELECT i.indexname, i.indexdef, c.contype
+            FROM pg_indexes i
+            LEFT JOIN pg_namespace ns
+                ON nspname = i.schemaname
+            LEFT JOIN pg_constraint c
+                ON c.conname = i.indexname
+                AND c.connamespace = ns.oid
+            WHERE i.schemaname = ? AND i.tablename = ?
+            SQL;
+
+        return $this->indexRows = $this->driver->query($query, [$tableSchema, $tableName])->fetchAll();
+    }
+
+    /**
+     * Fetch all single-column CHECK constraints of the table at once (they are used to detect
+     * enums emulated via CHECK), keyed by the textual representation of {@see pg_constraint.conkey}.
+     *
+     * @param array $schemas Rows of the column introspection query.
+     *
+     * @return array<string, list<array>>
+     */
+    private function fetchCheckConstraints(string $tableSchema, string $tableName, array $schemas): array
+    {
+        if (!$this->hasConstrainedColumns($schemas)) {
+            return [];
+        }
+
+        $query = <<<SQL
+            SELECT c.conname, c.conkey, pg_get_constraintdef(c.oid) as consrc
+            FROM pg_constraint c
+            JOIN pg_class cl
+                ON cl.oid = c.conrelid
+            JOIN pg_namespace ns
+                ON ns.oid = cl.relnamespace
+            WHERE ns.nspname = ? AND cl.relname = ? AND c.contype = 'c'
+            SQL;
+
+        $result = [];
+        foreach ($this->driver->query($query, [$tableSchema, $tableName]) as $constraint) {
+            $result[(string) $constraint['conkey']][] = $constraint;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Only `character`-like columns with a size may carry an emulated enum constraint,
+     * see {@see PostgresColumn::createInstance()}.
+     */
+    private function hasConstrainedColumns(array $schemas): bool
+    {
+        foreach ($schemas as $schema) {
+            if (
+                $schema['character_maximum_length'] !== null
+                && \str_contains((string) $schema['data_type'], 'char')
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Fetch value ranges of all native enum types used by the table with a single query.
+     *
+     * @param array $schemas Rows of the column introspection query.
+     *
+     * @return array<string, list<string>> Keyed as `<type schema>.<type name>`.
+     */
+    private function fetchEnumValues(array $schemas): array
+    {
+        $types = [];
+        foreach ($schemas as $schema) {
+            if ($schema['data_type'] === 'USER-DEFINED' && $schema['typtype'] === 'e') {
+                $types[$schema['udt_schema'] . '.' . $schema['udt_name']] = [
+                    $schema['udt_schema'],
+                    $schema['udt_name'],
+                ];
+            }
+        }
+
+        if ($types === []) {
+            return [];
+        }
+
+        $placeholders = \implode(', ', \array_fill(0, \count($types), '(?, ?)'));
+        $parameters = \array_merge(...\array_values($types));
+
+        $query = <<<SQL
+            SELECT ns.nspname, t.typname, e.enumlabel
+            FROM pg_enum e
+            JOIN pg_type t
+                ON t.oid = e.enumtypid
+            JOIN pg_namespace ns
+                ON ns.oid = t.typnamespace
+            WHERE (ns.nspname, t.typname) IN ({$placeholders})
+            ORDER BY e.enumsortorder
+            SQL;
+
+        $result = [];
+        foreach ($this->driver->query($query, $parameters) as $row) {
+            $result[$row['nspname'] . '.' . $row['typname']][] = $row['enumlabel'];
+        }
+
+        return $result;
     }
 }

--- a/src/Driver/SQLServer/Schema/SQLServerColumn.php
+++ b/src/Driver/SQLServer/Schema/SQLServerColumn.php
@@ -146,12 +146,19 @@ class SQLServerColumn extends AbstractColumn
 
     /**
      * @param DriverInterface $driver SQLServer columns are bit more complex.
+     * @param array|null $defaultConstraints Pre-fetched DEFAULT constraint names of the whole table
+     *        keyed by the constraint object id. When `null` the name is resolved with a dedicated query.
+     * @param array|null $checkConstraints Pre-fetched CHECK constraints of the whole table keyed as
+     *        `<table object id>:<column id>`. When `null` they are resolved with a dedicated query.
+     *
      * @psalm-param non-empty-string $table Table name.
      */
     public static function createInstance(
         string $table,
         array $schema,
         DriverInterface $driver,
+        ?array $defaultConstraints = null,
+        ?array $checkConstraints = null,
     ): self {
         $column = new self($table, $schema['COLUMN_NAME'], $driver->getTimezone());
 
@@ -185,12 +192,14 @@ class SQLServerColumn extends AbstractColumn
 
         if (!empty($schema['default_object_id'])) {
             //Looking for default constrain id
-            $column->defaultConstraint = $driver->query(
-                'SELECT [name] FROM [sys].[default_constraints] WHERE [object_id] = ?',
-                [
-                    $schema['default_object_id'],
-                ],
-            )->fetchColumn();
+            $column->defaultConstraint = $defaultConstraints !== null
+                ? ($defaultConstraints[(string) $schema['default_object_id']] ?? '')
+                : $driver->query(
+                    'SELECT [name] FROM [sys].[default_constraints] WHERE [object_id] = ?',
+                    [
+                        $schema['default_object_id'],
+                    ],
+                )->fetchColumn();
 
             if (!empty($column->defaultConstraint)) {
                 $column->constrainedDefault = true;
@@ -199,12 +208,13 @@ class SQLServerColumn extends AbstractColumn
 
         //Potential enum
         if ($column->type === 'varchar' && !empty($column->size)) {
-            self::resolveEnum($driver, $schema, $column);
+            self::resolveEnum($driver, $schema, $column, $checkConstraints);
         }
 
         return $column;
     }
 
+    #[\Override]
     public function getConstraints(): array
     {
         $constraints = parent::getConstraints();
@@ -220,11 +230,13 @@ class SQLServerColumn extends AbstractColumn
         return $constraints;
     }
 
+    #[\Override]
     public function getAbstractType(): string
     {
         return !empty($this->enumValues) ? 'enum' : parent::getAbstractType();
     }
 
+    #[\Override]
     public function enum(mixed $values): AbstractColumn
     {
         $this->enumValues = \array_map('strval', \is_array($values) ? $values : \func_get_args());
@@ -238,6 +250,7 @@ class SQLServerColumn extends AbstractColumn
         return $this;
     }
 
+    #[\Override]
     public function datetime(int $size = 0, mixed ...$attributes): self
     {
         $size === 0 ? $this->type('datetime') : $this->type('datetime2');
@@ -257,6 +270,7 @@ class SQLServerColumn extends AbstractColumn
      *
      * @psalm-return non-empty-string
      */
+    #[\Override]
     public function sqlStatement(DriverInterface $driver, bool $withEnum = true): string
     {
         if ($withEnum && $this->getAbstractType() === 'enum') {
@@ -352,6 +366,7 @@ class SQLServerColumn extends AbstractColumn
         return $operations;
     }
 
+    #[\Override]
     protected static function isJson(AbstractColumn $column): ?bool
     {
         // In SQL Server, we cannot determine if a column has a JSON type.
@@ -361,6 +376,7 @@ class SQLServerColumn extends AbstractColumn
     /**
      * @psalm-return non-empty-string
      */
+    #[\Override]
     protected function quoteDefault(DriverInterface $driver): string
     {
         $defaultValue = parent::quoteDefault($driver);
@@ -402,13 +418,18 @@ class SQLServerColumn extends AbstractColumn
         DriverInterface $driver,
         array $schema,
         self $column,
+        ?array $checkConstraints = null,
     ): void {
-        $query = 'SELECT object_definition([o].[object_id]) AS [definition], '
-            . "OBJECT_NAME([o].[object_id]) AS [name]\nFROM [sys].[objects] AS [o]\n"
-            . "JOIN [sys].[sysconstraints] AS [c] ON [o].[object_id] = [c].[constid]\n"
-            . "WHERE [type_desc] = 'CHECK_CONSTRAINT' AND [parent_object_id] = ? AND [c].[colid] = ?";
+        if ($checkConstraints !== null) {
+            $constraints = $checkConstraints[$schema['object_id'] . ':' . $schema['column_id']] ?? [];
+        } else {
+            $query = 'SELECT object_definition([o].[object_id]) AS [definition], '
+                . "OBJECT_NAME([o].[object_id]) AS [name]\nFROM [sys].[objects] AS [o]\n"
+                . "JOIN [sys].[sysconstraints] AS [c] ON [o].[object_id] = [c].[constid]\n"
+                . "WHERE [type_desc] = 'CHECK_CONSTRAINT' AND [parent_object_id] = ? AND [c].[colid] = ?";
 
-        $constraints = $driver->query($query, [$schema['object_id'], $schema['column_id']]);
+            $constraints = $driver->query($query, [$schema['object_id'], $schema['column_id']]);
+        }
 
         foreach ($constraints as $constraint) {
             $column->enumConstraint = $constraint['name'];

--- a/src/Driver/SQLServer/Schema/SQLServerTable.php
+++ b/src/Driver/SQLServer/Schema/SQLServerTable.php
@@ -24,6 +24,7 @@ class SQLServerTable extends AbstractTable
      *
      * SQLServer will reload schemas after successful savw.
      */
+    #[\Override]
     public function save(int $operation = HandlerInterface::DO_ALL, bool $reset = true): void
     {
         parent::save($operation, $reset);
@@ -39,25 +40,47 @@ class SQLServerTable extends AbstractTable
         }
     }
 
+    #[\Override]
     protected function fetchColumns(): array
     {
         $query = 'SELECT * FROM [information_schema].[columns] INNER JOIN [sys].[columns] AS [sysColumns] '
             . 'ON (object_name([object_id]) = [table_name] AND [sysColumns].[name] = [COLUMN_NAME]) '
             . 'WHERE [table_name] = ?';
 
+        $schemas = $this->driver->query($query, [$this->getFullName()])->fetchAll();
+
+        if ($schemas === []) {
+            return [];
+        }
+
+        // The queries above are not scoped by the table schema, so the rows may belong to several
+        // same-named tables from different schemas. Constraints are batched per object to keep
+        // the resolution correct for every row.
+        $objectIds = [];
+        foreach ($schemas as $schema) {
+            $objectIds[(string) $schema['object_id']] = $schema['object_id'];
+        }
+        $objectIds = \array_values($objectIds);
+
+        $defaultConstraints = $this->fetchDefaultConstraints($objectIds, $schemas);
+        $checkConstraints = $this->fetchCheckConstraints($objectIds, $schemas);
+
         $result = [];
-        foreach ($this->driver->query($query, [$this->getFullName()]) as $schema) {
+        foreach ($schemas as $schema) {
             //Column initialization needs driver to properly resolve enum type
             $result[] = SQLServerColumn::createInstance(
                 $this->getFullName(),
                 $schema,
                 $this->driver,
+                $defaultConstraints,
+                $checkConstraints,
             );
         }
 
         return $result;
     }
 
+    #[\Override]
     protected function fetchIndexes(): array
     {
         $query = 'SELECT [indexes].[name] AS [indexName], '
@@ -87,6 +110,7 @@ class SQLServerTable extends AbstractTable
         return $result;
     }
 
+    #[\Override]
     protected function fetchReferences(): array
     {
         $query = $this->driver->query('sp_fkeys @fktable_name = ?', [$this->getFullName()]);
@@ -117,6 +141,7 @@ class SQLServerTable extends AbstractTable
         return $result;
     }
 
+    #[\Override]
     protected function fetchPrimaryKeys(): array
     {
         $query = "SELECT [indexes].[name] AS [indexName], [cl].[name] AS [columnName]\n"
@@ -138,18 +163,89 @@ class SQLServerTable extends AbstractTable
         return $result;
     }
 
+    #[\Override]
     protected function createColumn(string $name): AbstractColumn
     {
         return new SQLServerColumn($this->getFullName(), $name, $this->driver->getTimezone());
     }
 
+    #[\Override]
     protected function createIndex(string $name): AbstractIndex
     {
         return new SQLServerIndex($this->getFullName(), $name);
     }
 
+    #[\Override]
     protected function createForeign(string $name): AbstractForeignKey
     {
         return new SQlServerForeignKey($this->getFullName(), $this->getPrefix(), $name);
+    }
+
+    /**
+     * Fetch names of all DEFAULT constraints of the given tables at once, keyed by the constraint
+     * object id (it is unique database-wide).
+     *
+     * @return array<array-key, string>
+     */
+    private function fetchDefaultConstraints(array $objectIds, array $schemas): array
+    {
+        $required = false;
+        foreach ($schemas as $schema) {
+            if (!empty($schema['default_object_id'])) {
+                $required = true;
+                break;
+            }
+        }
+
+        if (!$required) {
+            return [];
+        }
+
+        $placeholders = \implode(', ', \array_fill(0, \count($objectIds), '?'));
+        $query = "SELECT [object_id], [name] FROM [sys].[default_constraints]
+            WHERE [parent_object_id] IN ({$placeholders})";
+
+        $result = [];
+        foreach ($this->driver->query($query, $objectIds) as $constraint) {
+            $result[(string) $constraint['object_id']] = $constraint['name'];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Fetch all CHECK constraints of the given tables at once (they are used to detect emulated
+     * enums), keyed as `<table object id>:<column id>` — the column id alone is ambiguous when
+     * the rows belong to more than one table.
+     *
+     * @return array<array-key, list<array>>
+     */
+    private function fetchCheckConstraints(array $objectIds, array $schemas): array
+    {
+        $required = false;
+        foreach ($schemas as $schema) {
+            if ($schema['DATA_TYPE'] === 'varchar' && !empty($schema['CHARACTER_MAXIMUM_LENGTH'])) {
+                $required = true;
+                break;
+            }
+        }
+
+        if (!$required) {
+            return [];
+        }
+
+        $placeholders = \implode(', ', \array_fill(0, \count($objectIds), '?'));
+        $query = 'SELECT object_definition([o].[object_id]) AS [definition], '
+            . "OBJECT_NAME([o].[object_id]) AS [name], [o].[parent_object_id] AS [parentId], [c].[colid] AS [colid]\n"
+            . "FROM [sys].[objects] AS [o]\n"
+            . "JOIN [sys].[sysconstraints] AS [c] ON [o].[object_id] = [c].[constid]\n"
+            . "WHERE [type_desc] = 'CHECK_CONSTRAINT' AND [parent_object_id] IN ({$placeholders})";
+
+        $result = [];
+        foreach ($this->driver->query($query, $objectIds) as $constraint) {
+            $result[$constraint['parentId'] . ':' . $constraint['colid']][] = $constraint;
+        }
+
+        return $result;
     }
 }

--- a/src/Driver/SQLite/Schema/SQLiteTable.php
+++ b/src/Driver/SQLite/Schema/SQLiteTable.php
@@ -18,6 +18,19 @@ use Cycle\Database\Schema\AbstractTable;
 
 class SQLiteTable extends AbstractTable
 {
+    /**
+     * Memoized `PRAGMA TABLE_INFO` result. It is requested by {@see fetchColumns()} and
+     * {@see fetchPrimaryKeys()}, and the latter is called more than once per introspection.
+     */
+    private ?array $tableInfo = null;
+
+    #[\Override]
+    protected function resetIntrospectionCache(): void
+    {
+        $this->tableInfo = null;
+    }
+
+    #[\Override]
     protected function fetchColumns(): array
     {
         /**
@@ -52,6 +65,7 @@ class SQLiteTable extends AbstractTable
         return $result;
     }
 
+    #[\Override]
     protected function fetchIndexes(): array
     {
         $primaryKeys = $this->fetchPrimaryKeys();
@@ -84,6 +98,7 @@ class SQLiteTable extends AbstractTable
         return $result;
     }
 
+    #[\Override]
     protected function fetchReferences(): array
     {
         $query = "PRAGMA foreign_key_list({$this->driver->quote($this->getFullName())})";
@@ -116,8 +131,8 @@ class SQLiteTable extends AbstractTable
 
     /**
      * Fetching primary keys from table.
-     *
      */
+    #[\Override]
     protected function fetchPrimaryKeys(): array
     {
         $primaryKeys = [];
@@ -130,16 +145,19 @@ class SQLiteTable extends AbstractTable
         return $primaryKeys;
     }
 
+    #[\Override]
     protected function createColumn(string $name): AbstractColumn
     {
         return new SQLiteColumn($this->getFullName(), $name, $this->driver->getTimezone());
     }
 
+    #[\Override]
     protected function createIndex(string $name): AbstractIndex
     {
         return new SQLiteIndex($this->getFullName(), $name);
     }
 
+    #[\Override]
     protected function createForeign(string $name): AbstractForeignKey
     {
         return new SQLiteForeignKey($this->getFullName(), $this->getPrefix(), $name);
@@ -147,17 +165,20 @@ class SQLiteTable extends AbstractTable
 
     /**
      * @param array $include Include following parameters into each line.
-     *
      */
     private function columnSchemas(array $include = []): array
     {
-        $columns = $this->driver->query(
+        $this->tableInfo ??= $this->driver->query(
             'PRAGMA TABLE_INFO(' . $this->driver->quote($this->getFullName()) . ')',
-        );
+        )->fetchAll();
+
+        if ($include === []) {
+            return $this->tableInfo;
+        }
 
         $result = [];
 
-        foreach ($columns as $column) {
+        foreach ($this->tableInfo as $column) {
             $result[] = $column + $include;
         }
 

--- a/src/Schema/AbstractTable.php
+++ b/src/Schema/AbstractTable.php
@@ -145,6 +145,7 @@ abstract class AbstractTable implements TableInterface, ElementInterface
         return new Comparator($this->initial, $this->current);
     }
 
+    #[\Override]
     public function exists(): bool
     {
         // Declared as dropped != actually dropped
@@ -176,6 +177,7 @@ abstract class AbstractTable implements TableInterface, ElementInterface
     /**
      * @psalm-return non-empty-string
      */
+    #[\Override]
     public function getName(): string
     {
         return $this->getFullName();
@@ -184,6 +186,7 @@ abstract class AbstractTable implements TableInterface, ElementInterface
     /**
      * @psalm-return non-empty-string
      */
+    #[\Override]
     public function getFullName(): string
     {
         return $this->current->getName();
@@ -228,11 +231,13 @@ abstract class AbstractTable implements TableInterface, ElementInterface
         return $this;
     }
 
+    #[\Override]
     public function getPrimaryKeys(): array
     {
         return $this->current->getPrimaryKeys();
     }
 
+    #[\Override]
     public function hasColumn(string $name): bool
     {
         return $this->current->hasColumn($name);
@@ -241,11 +246,13 @@ abstract class AbstractTable implements TableInterface, ElementInterface
     /**
      * @return AbstractColumn[]
      */
+    #[\Override]
     public function getColumns(): array
     {
         return $this->current->getColumns();
     }
 
+    #[\Override]
     public function hasIndex(array $columns = []): bool
     {
         return $this->current->hasIndex($columns);
@@ -254,11 +261,13 @@ abstract class AbstractTable implements TableInterface, ElementInterface
     /**
      * @return AbstractIndex[]
      */
+    #[\Override]
     public function getIndexes(): array
     {
         return $this->current->getIndexes();
     }
 
+    #[\Override]
     public function hasForeignKey(array $columns): bool
     {
         return $this->current->hasForeignKey($columns);
@@ -267,11 +276,13 @@ abstract class AbstractTable implements TableInterface, ElementInterface
     /**
      * @return AbstractForeignKey[]
      */
+    #[\Override]
     public function getForeignKeys(): array
     {
         return $this->current->getForeignKeys();
     }
 
+    #[\Override]
     public function getDependencies(): array
     {
         $tables = [];
@@ -586,6 +597,9 @@ abstract class AbstractTable implements TableInterface, ElementInterface
             }
         }
 
+        // Introspection results are not valid anymore
+        $this->resetIntrospectionCache();
+
         // Syncing our schemas
         if ($reset) {
             $this->status = self::STATUS_EXISTS;
@@ -760,6 +774,8 @@ abstract class AbstractTable implements TableInterface, ElementInterface
      */
     protected function initSchema(State $state): void
     {
+        $this->resetIntrospectionCache();
+
         foreach ($this->fetchColumns() as $column) {
             $state->registerColumn($column);
         }
@@ -779,6 +795,15 @@ abstract class AbstractTable implements TableInterface, ElementInterface
     protected function isIndexColumnSortingSupported(): bool
     {
         return true;
+    }
+
+    /**
+     * Drop driver specific introspection results memoized for the duration of a single
+     * introspection pass. Called before the schema is read and after it has been modified.
+     */
+    protected function resetIntrospectionCache(): void
+    {
+        // Nothing to do by default.
     }
 
     /**

--- a/tests/Database/Functional/Driver/Common/Schema/IntrospectionQueryCountTest.php
+++ b/tests/Database/Functional/Driver/Common/Schema/IntrospectionQueryCountTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\Common\Schema;
+
+use Cycle\Database\Driver\Handler;
+use Cycle\Database\Schema\AbstractTable;
+use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\Database\Tests\Utils\QueryCounter;
+
+/**
+ * Introspection of a single table must cost a constant number of queries: it should not grow with
+ * the number of columns, indexes or foreign keys of that table.
+ */
+abstract class IntrospectionQueryCountTest extends BaseTest
+{
+    /**
+     * Shape of the sample table used by {@see testWideTableIntrospectionIsCheap()}. Driver
+     * specific overrides of {@see getIntrospectionQueryLimit()} derive their limits from it.
+     */
+    protected const WIDE_COLUMNS = 40;
+
+    protected const WIDE_INDEXES = 3;
+    protected const WIDE_FOREIGN_KEYS = 1;
+
+    private QueryCounter $counter;
+
+    public function testColumnCountDoesNotAffectQueryCount(): void
+    {
+        $this->makeParents(1);
+
+        $this->makeTable('narrow', columns: 2, indexes: 1, foreignKeys: 1);
+        $this->makeTable('wide', columns: 40, indexes: 1, foreignKeys: 1);
+
+        $narrow = $this->countIntrospectionQueries('narrow');
+        $wide = $this->countIntrospectionQueries('wide');
+
+        $this->assertSame(
+            $narrow[0],
+            $wide[0],
+            \sprintf(
+                "Introspection of a 40 column table took %d queries instead of %d.\n\nNarrow:\n%s\n\nWide:\n%s",
+                $wide[0],
+                $narrow[0],
+                $narrow[1],
+                $wide[1],
+            ),
+        );
+    }
+
+    public function testForeignKeyCountDoesNotAffectQueryCount(): void
+    {
+        $this->makeParents(5);
+
+        $this->makeTable('single', columns: 2, indexes: 0, foreignKeys: 1);
+        $this->makeTable('many', columns: 2, indexes: 0, foreignKeys: 5);
+
+        $single = $this->countIntrospectionQueries('single');
+        $many = $this->countIntrospectionQueries('many');
+
+        $this->assertSame(
+            $single[0],
+            $many[0],
+            \sprintf(
+                "Introspection of a table with 5 foreign keys took %d queries instead of %d.\n\n"
+                . "Single:\n%s\n\nMany:\n%s",
+                $many[0],
+                $single[0],
+                $single[1],
+                $many[1],
+            ),
+        );
+    }
+
+    public function testIndexCountDoesNotAffectQueryCount(): void
+    {
+        $this->makeTable('single', columns: 5, indexes: 1, foreignKeys: 0);
+        $this->makeTable('many', columns: 5, indexes: 5, foreignKeys: 0);
+
+        $single = $this->countIntrospectionQueries('single');
+        $many = $this->countIntrospectionQueries('many');
+
+        $this->assertSame(
+            $single[0],
+            $many[0],
+            \sprintf(
+                "Introspection of a table with 5 indexes took %d queries instead of %d.\n\n"
+                . "Single:\n%s\n\nMany:\n%s",
+                $many[0],
+                $single[0],
+                $single[1],
+                $many[1],
+            ),
+        );
+    }
+
+    /**
+     * Wide table introspection must not degrade into dozens of round trips even in absolute numbers.
+     */
+    public function testWideTableIntrospectionIsCheap(): void
+    {
+        $this->makeParents(static::WIDE_FOREIGN_KEYS);
+        $this->makeTable(
+            'wide',
+            columns: static::WIDE_COLUMNS,
+            indexes: static::WIDE_INDEXES,
+            foreignKeys: static::WIDE_FOREIGN_KEYS,
+        );
+
+        [$count, $queries] = $this->countIntrospectionQueries('wide');
+
+        $this->assertLessThanOrEqual(
+            $this->getIntrospectionQueryLimit(),
+            $count,
+            "Too many introspection queries:\n{$queries}",
+        );
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->counter = new QueryCounter();
+    }
+
+    public function tearDown(): void
+    {
+        $this->database->getDriver()->setLogger(static::$logger);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Maximum number of queries a single table introspection is allowed to make.
+     */
+    protected function getIntrospectionQueryLimit(): int
+    {
+        return 10;
+    }
+
+    /**
+     * @return array{0: int, 1: QueryCounter}
+     */
+    protected function countIntrospectionQueries(string $table): array
+    {
+        $driver = $this->database->getDriver();
+
+        $this->counter->reset();
+        $driver->setLogger($this->counter);
+
+        try {
+            $schema = $this->schema($table);
+            $this->assertTrue($schema->exists());
+        } finally {
+            $driver->setLogger(static::$logger);
+        }
+
+        return [$this->counter->count(), clone $this->counter];
+    }
+
+    protected function makeParents(int $count): void
+    {
+        for ($i = 0; $i < $count; $i++) {
+            $schema = $this->schema("parent_{$i}");
+            $schema->primary('id');
+            $schema->save(Handler::DO_ALL);
+        }
+    }
+
+    protected function makeTable(string $name, int $columns, int $indexes, int $foreignKeys): AbstractTable
+    {
+        $schema = $this->schema($name);
+        $schema->primary('id');
+
+        // `string` with a size and a default value is the worst case: it triggers both the CHECK
+        // constraint lookup (emulated enums) and the DEFAULT constraint lookup.
+        for ($i = 0; $i < $columns; $i++) {
+            $schema->string("column_{$i}", 64)->defaultValue("value_{$i}");
+        }
+
+        // A native enum is resolved separately from the emulated ones.
+        $schema->enum('status', ['active', 'disabled'])->defaultValue('active');
+
+        for ($i = 0; $i < $indexes; $i++) {
+            $schema->integer("indexed_{$i}")->defaultValue(0);
+            $schema->index(["indexed_{$i}"]);
+        }
+
+        for ($i = 0; $i < $foreignKeys; $i++) {
+            $schema->integer("parent_{$i}_id")->nullable(true);
+            $schema->foreignKey(["parent_{$i}_id"])->references("parent_{$i}", ['id']);
+        }
+
+        $schema->save(Handler::DO_ALL);
+
+        return $schema;
+    }
+}

--- a/tests/Database/Functional/Driver/MySQL/Schema/IntrospectionQueryCountTest.php
+++ b/tests/Database/Functional/Driver/MySQL/Schema/IntrospectionQueryCountTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\MySQL\Schema;
+
+// phpcs:ignore
+use Cycle\Database\Tests\Functional\Driver\Common\Schema\IntrospectionQueryCountTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class IntrospectionQueryCountTest extends CommonClass
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/Database/Functional/Driver/Postgres/Schema/EnumIntrospectionTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Schema/EnumIntrospectionTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\Postgres\Schema;
+
+use Cycle\Database\Exception\StatementException;
+use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
+
+/**
+ * Native enums and enums emulated via a CHECK constraint are resolved with two batched queries,
+ * so their combinations in a single table need explicit coverage.
+ *
+ * @group driver
+ * @group driver-postgres
+ */
+class EnumIntrospectionTest extends BaseTest
+{
+    public const DRIVER = 'postgres';
+
+    public function testNativeAndEmulatedEnumsInSingleTable(): void
+    {
+        $driver = $this->database->getDriver();
+
+        $driver->execute("CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')");
+        $driver->execute("CREATE TYPE weather AS ENUM ('rain', 'sun')");
+        $driver->execute(
+            'CREATE TABLE mixed_enums (
+                id serial NOT NULL,
+                name text,
+                current_mood mood,
+                forecast weather,
+                plain_string character varying(64),
+                status character varying(16),
+                CONSTRAINT mixed_enums_status_check CHECK (status IN (\'active\', \'disabled\')),
+                CONSTRAINT mixed_enums_pkey PRIMARY KEY (id)
+            )',
+        );
+
+        $schema = $driver->getSchema('mixed_enums');
+
+        // Two different native enum types
+        $this->assertSame('enum', $schema->column('current_mood')->getAbstractType());
+        $this->assertSame(['sad', 'ok', 'happy'], $schema->column('current_mood')->getEnumValues());
+
+        $this->assertSame('enum', $schema->column('forecast')->getAbstractType());
+        $this->assertSame(['rain', 'sun'], $schema->column('forecast')->getEnumValues());
+
+        // Enum emulated via a CHECK constraint
+        $this->assertSame('enum', $schema->column('status')->getAbstractType());
+        $this->assertSame(['active', 'disabled'], $schema->column('status')->getEnumValues());
+
+        // A varchar without a constraint must stay a plain string
+        $this->assertSame('string', $schema->column('plain_string')->getAbstractType());
+        $this->assertSame([], $schema->column('plain_string')->getEnumValues());
+
+        $this->assertSame(['id'], $schema->getPrimaryKeys());
+    }
+
+    /**
+     * The enum type of a column must be resolved by both the type name and the type schema:
+     * same-named enum types from other schemas must not interfere, and a type outside of the
+     * `search_path` must still be resolvable.
+     */
+    public function testSameNamedEnumsInDifferentSchemas(): void
+    {
+        $driver = $this->database->getDriver();
+
+        $driver->execute('CREATE SCHEMA enum_intro');
+        $driver->execute("CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')");
+        $driver->execute("CREATE TYPE enum_intro.mood AS ENUM ('angry', 'calm')");
+        $driver->execute(
+            'CREATE TABLE mixed_enums (
+                id serial NOT NULL,
+                public_mood mood,
+                foreign_mood enum_intro.mood,
+                CONSTRAINT mixed_enums_pkey PRIMARY KEY (id)
+            )',
+        );
+
+        $schema = $driver->getSchema('mixed_enums');
+
+        $this->assertSame('enum', $schema->column('public_mood')->getAbstractType());
+        $this->assertSame(['sad', 'ok', 'happy'], $schema->column('public_mood')->getEnumValues());
+
+        $this->assertSame('enum', $schema->column('foreign_mood')->getAbstractType());
+        $this->assertSame(['angry', 'calm'], $schema->column('foreign_mood')->getEnumValues());
+    }
+
+    public function testCompositePrimaryKeyWithEmulatedEnum(): void
+    {
+        $driver = $this->database->getDriver();
+
+        $driver->execute(
+            'CREATE TABLE mixed_enums (
+                left_id integer NOT NULL,
+                right_id integer NOT NULL,
+                status character varying(16),
+                CONSTRAINT mixed_enums_status_check CHECK (status IN (\'active\', \'disabled\')),
+                CONSTRAINT mixed_enums_pkey PRIMARY KEY (left_id, right_id)
+            )',
+        );
+
+        $schema = $driver->getSchema('mixed_enums');
+
+        $this->assertSame(['left_id', 'right_id'], $schema->getPrimaryKeys());
+        $this->assertSame(['active', 'disabled'], $schema->column('status')->getEnumValues());
+        // The composite PK constraint must not be reported as a regular index
+        $this->assertSame([], $schema->getIndexes());
+    }
+
+    public function tearDown(): void
+    {
+        $driver = $this->database->getDriver();
+
+        foreach (['mixed_enums'] as $table) {
+            try {
+                $driver->execute("DROP TABLE IF EXISTS {$table}");
+            } catch (StatementException) {
+            }
+        }
+
+        foreach (['mood', 'weather'] as $type) {
+            try {
+                $driver->execute("DROP TYPE IF EXISTS {$type}");
+            } catch (StatementException) {
+            }
+        }
+
+        try {
+            $driver->execute('DROP SCHEMA IF EXISTS enum_intro CASCADE');
+        } catch (StatementException) {
+        }
+
+        parent::tearDown();
+    }
+}

--- a/tests/Database/Functional/Driver/Postgres/Schema/EnumIntrospectionTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Schema/EnumIntrospectionTest.php
@@ -87,6 +87,58 @@ class EnumIntrospectionTest extends BaseTest
         $this->assertSame(['angry', 'calm'], $schema->column('foreign_mood')->getEnumValues());
     }
 
+    /**
+     * Labels are read from `pg_enum` one row per label, so values with commas, quotes or spaces
+     * are returned verbatim. The former `enum_range()` parsing split the textual range by a comma
+     * and mangled such labels.
+     */
+    public function testLabelsWithSpecialCharacters(): void
+    {
+        $driver = $this->database->getDriver();
+
+        $driver->execute(
+            "CREATE TYPE dirty_labels AS ENUM ('it''s', 'a,b', 'with \"quotes\"', ' spaced ')",
+        );
+        $driver->execute(
+            'CREATE TABLE mixed_enums (
+                id serial NOT NULL,
+                label dirty_labels,
+                CONSTRAINT mixed_enums_pkey PRIMARY KEY (id)
+            )',
+        );
+
+        $schema = $driver->getSchema('mixed_enums');
+
+        $this->assertSame('enum', $schema->column('label')->getAbstractType());
+        $this->assertSame(
+            ["it's", 'a,b', 'with "quotes"', ' spaced '],
+            $schema->column('label')->getEnumValues(),
+        );
+    }
+
+    /**
+     * An enum type without labels has no values, so the column must not be reported as an enum.
+     * The former `enum_range()` parsing produced a single empty-string value for it.
+     */
+    public function testEmptyEnumType(): void
+    {
+        $driver = $this->database->getDriver();
+
+        $driver->execute('CREATE TYPE empty_enum AS ENUM ()');
+        $driver->execute(
+            'CREATE TABLE mixed_enums (
+                id serial NOT NULL,
+                hollow empty_enum,
+                CONSTRAINT mixed_enums_pkey PRIMARY KEY (id)
+            )',
+        );
+
+        $schema = $driver->getSchema('mixed_enums');
+
+        $this->assertNotSame('enum', $schema->column('hollow')->getAbstractType());
+        $this->assertSame([], $schema->column('hollow')->getEnumValues());
+    }
+
     public function testCompositePrimaryKeyWithEmulatedEnum(): void
     {
         $driver = $this->database->getDriver();
@@ -120,7 +172,7 @@ class EnumIntrospectionTest extends BaseTest
             }
         }
 
-        foreach (['mood', 'weather'] as $type) {
+        foreach (['mood', 'weather', 'dirty_labels', 'empty_enum'] as $type) {
             try {
                 $driver->execute("DROP TYPE IF EXISTS {$type}");
             } catch (StatementException) {

--- a/tests/Database/Functional/Driver/Postgres/Schema/IntrospectionQueryCountTest.php
+++ b/tests/Database/Functional/Driver/Postgres/Schema/IntrospectionQueryCountTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\Postgres\Schema;
+
+// phpcs:ignore
+use Cycle\Database\Tests\Functional\Driver\Common\Schema\IntrospectionQueryCountTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class IntrospectionQueryCountTest extends CommonClass
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/Database/Functional/Driver/SQLServer/Schema/CrossSchemaIntrospectionTest.php
+++ b/tests/Database/Functional/Driver/SQLServer/Schema/CrossSchemaIntrospectionTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\SQLServer\Schema;
+
+use Cycle\Database\Exception\StatementException;
+use Cycle\Database\Tests\Functional\Driver\Common\BaseTest;
+
+/**
+ * Table introspection queries are scoped by the table name only, so a same-named table in another
+ * schema contributes its rows too. The constraint batches must stay correct for every row: each
+ * column must resolve the CHECK (emulated enum) and DEFAULT constraints of its own table.
+ *
+ * @group driver
+ * @group driver-sqlserver
+ */
+class CrossSchemaIntrospectionTest extends BaseTest
+{
+    public const DRIVER = 'sqlserver';
+
+    public function testSameNamedTablesInDifferentSchemas(): void
+    {
+        $driver = $this->database->getDriver();
+
+        $driver->execute('CREATE SCHEMA [intro_other]');
+        $driver->execute(
+            "CREATE TABLE [dbo].[intro_dup] (
+                [id] int NOT NULL,
+                [status] varchar(16) NOT NULL CONSTRAINT [intro_dup_status_default] DEFAULT 'active',
+                CONSTRAINT [intro_dup_status_check] CHECK ([status] IN ('active', 'disabled'))
+            )",
+        );
+        // The padding columns shift [mode] to a column id different from the one [status] has
+        // in [dbo].[intro_dup].
+        $driver->execute(
+            "CREATE TABLE [intro_other].[intro_dup] (
+                [id] int NOT NULL,
+                [padding_a] int,
+                [padding_b] int,
+                [mode] varchar(8) NOT NULL CONSTRAINT [intro_dup_mode_default] DEFAULT 'x',
+                CONSTRAINT [intro_dup_mode_check] CHECK ([mode] IN ('x', 'y'))
+            )",
+        );
+
+        $schema = $driver->getSchema('intro_dup');
+
+        $status = $schema->column('status');
+        $this->assertSame('enum', $status->getAbstractType());
+        $this->assertSame(['active', 'disabled'], $status->getEnumValues());
+        $this->assertContains('intro_dup_status_default', $status->getConstraints());
+        $this->assertContains('intro_dup_status_check', $status->getConstraints());
+
+        $mode = $schema->column('mode');
+        $this->assertSame('enum', $mode->getAbstractType());
+        $this->assertSame(['x', 'y'], $mode->getEnumValues());
+        $this->assertContains('intro_dup_mode_default', $mode->getConstraints());
+        $this->assertContains('intro_dup_mode_check', $mode->getConstraints());
+    }
+
+    public function tearDown(): void
+    {
+        $driver = $this->database->getDriver();
+
+        foreach (['[dbo].[intro_dup]', '[intro_other].[intro_dup]'] as $table) {
+            try {
+                $driver->execute("DROP TABLE IF EXISTS {$table}");
+            } catch (StatementException) {
+            }
+        }
+
+        try {
+            $driver->execute('DROP SCHEMA IF EXISTS [intro_other]');
+        } catch (StatementException) {
+        }
+
+        parent::tearDown();
+    }
+}

--- a/tests/Database/Functional/Driver/SQLServer/Schema/IntrospectionQueryCountTest.php
+++ b/tests/Database/Functional/Driver/SQLServer/Schema/IntrospectionQueryCountTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\SQLServer\Schema;
+
+// phpcs:ignore
+use Cycle\Database\Tests\Functional\Driver\Common\Schema\IntrospectionQueryCountTest as CommonClass;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class IntrospectionQueryCountTest extends CommonClass
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/Database/Functional/Driver/SQLite/Schema/IntrospectionQueryCountTest.php
+++ b/tests/Database/Functional/Driver/SQLite/Schema/IntrospectionQueryCountTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Functional\Driver\SQLite\Schema;
+
+// phpcs:ignore
+use Cycle\Database\Tests\Functional\Driver\Common\Schema\IntrospectionQueryCountTest as CommonClass;
+use Cycle\Database\Tests\Utils\QueryCounter;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class IntrospectionQueryCountTest extends CommonClass
+{
+    public const DRIVER = 'sqlite';
+
+    /**
+     * Every index is read with a pair of `PRAGMA INDEX_XINFO` / `PRAGMA INDEX_INFO` calls,
+     * see {@see \Cycle\Database\Driver\SQLite\Schema\SQLiteTable::fetchIndexes()}.
+     */
+    private const QUERIES_PER_INDEX = 2;
+
+    /**
+     * Queries a table introspection costs on its own: `hasTable`, `sqlite_master`, `TABLE_INFO`,
+     * `index_list` and `foreign_key_list`.
+     */
+    private const QUERIES_PER_TABLE = 5;
+
+    /**
+     * SQLite reads every index with a pair of PRAGMA calls. It is an embedded engine without
+     * network round trips, so the per-index cost is acceptable, and the growth is asserted
+     * to be exactly linear instead of constant.
+     */
+    public function testIndexCountDoesNotAffectQueryCount(): void
+    {
+        $singleIndexes = 1;
+        $manyIndexes = 5;
+
+        $this->makeTable('single', columns: 5, indexes: $singleIndexes, foreignKeys: 0);
+        $this->makeTable('many', columns: 5, indexes: $manyIndexes, foreignKeys: 0);
+
+        [$single] = $this->countIntrospectionQueries('single');
+        [$many] = $this->countIntrospectionQueries('many');
+
+        $this->assertSame(self::QUERIES_PER_INDEX * ($manyIndexes - $singleIndexes), $many - $single);
+    }
+
+    /**
+     * Every foreign key implies an index over its columns, so this case degrades into the per-index
+     * cost described in {@see testIndexCountDoesNotAffectQueryCount()}. The foreign keys themselves
+     * are still read with a single `PRAGMA foreign_key_list`.
+     */
+    public function testForeignKeyCountDoesNotAffectQueryCount(): void
+    {
+        $singleForeignKeys = 1;
+        $manyForeignKeys = 5;
+
+        $this->makeParents($manyForeignKeys);
+
+        $this->makeTable('single', columns: 2, indexes: 0, foreignKeys: $singleForeignKeys);
+        $this->makeTable('many', columns: 2, indexes: 0, foreignKeys: $manyForeignKeys);
+
+        [$single, $singleQueries] = $this->countIntrospectionQueries('single');
+        [$many, $manyQueries] = $this->countIntrospectionQueries('many');
+
+        $this->assertSame(
+            self::QUERIES_PER_INDEX * ($manyForeignKeys - $singleForeignKeys),
+            $many - $single,
+        );
+        $this->assertSame(1, $this->countMatching($singleQueries, 'foreign_key_list'));
+        $this->assertSame(1, $this->countMatching($manyQueries, 'foreign_key_list'));
+    }
+
+    /**
+     * The sample table carries an index per every explicit index and foreign key.
+     */
+    protected function getIntrospectionQueryLimit(): int
+    {
+        return self::QUERIES_PER_TABLE
+            + self::QUERIES_PER_INDEX * (static::WIDE_INDEXES + static::WIDE_FOREIGN_KEYS);
+    }
+
+    private function countMatching(QueryCounter $counter, string $needle): int
+    {
+        $count = 0;
+        foreach ($counter->getQueries() as $query) {
+            if (\str_contains($query, $needle)) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+}

--- a/tests/Database/Utils/QueryCounter.php
+++ b/tests/Database/Utils/QueryCounter.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Tests\Utils;
+
+use Psr\Log\AbstractLogger;
+
+/**
+ * Counts SQL statements executed by a driver.
+ *
+ * Only records produced for real statements are counted: driver emits them with the `elapsed` key
+ * in the context, while transaction/savepoint messages carry no context at all.
+ */
+final class QueryCounter extends AbstractLogger
+{
+    /** @var list<string> */
+    private array $queries = [];
+
+    public function log($level, $message, array $context = []): void
+    {
+        if (!\array_key_exists('elapsed', $context)) {
+            return;
+        }
+
+        $this->queries[] = (string) $message;
+    }
+
+    public function reset(): void
+    {
+        $this->queries = [];
+    }
+
+    public function count(): int
+    {
+        return \count($this->queries);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getQueries(): array
+    {
+        return $this->queries;
+    }
+
+    public function __toString(): string
+    {
+        $result = [];
+        foreach ($this->queries as $i => $query) {
+            $result[] = \sprintf('%d. %s', $i + 1, \preg_replace('/\s+/', ' ', $query));
+        }
+
+        return \implode("\n", $result);
+    }
+}


### PR DESCRIPTION
## 🔍 What was changed

- Table introspection batches its catalogue queries: CHECK/DEFAULT constraints and enum ranges are read once per table instead of once per column, and the index query is shared between `fetchIndexes()` and `fetchPrimaryKeys()`. Introspecting a 40-column table drops from dozens of round trips to a handful.
- New `AbstractTable::resetIntrospectionCache()` hook clears the memoized state before a schema is read and after DDL is applied.
- Postgres native enums resolve by type schema and name via `pg_enum` instead of `enum_range()` over the `search_path`. This fixes three bugs of the old text-based parsing:
  - a column typed with an enum from another schema picked up the values of a same-named type;
  - labels containing commas or quotes (`'a,b'`, `'it''s'`) were split incorrectly — they are now returned verbatim;
  - an enum type without labels was reported as an enum with a single empty-string value — it is no longer treated as an enum.

The per-column queries stay as a fallback: the new `createInstance()` arguments are optional, so third-party callers are unaffected.

## Why?

Introspection cost one query per column and per constraint, which dominates schema sync against a remote database.

## Checklist

- Related issue: cycle/orm#466 (introspection round trips are one part of the slow schema sync)
- How was this tested:
  - [x] Unit tests added
  - [x] SQLite, MySQL, SQL Server and Postgres suites pass locally
