### PR TITLE
add getDateTimeFormat() method to \Cycle\Database\Driver\Driver

### DIFF
--- a/src/Driver/DateTimeFormatInterface.php
+++ b/src/Driver/DateTimeFormatInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of Cycle ORM package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Database\Driver;
+
+/**
+ * The methods of this interface should be part of Cycle\Database\Driver\DriverInterface,
+ * but adding new methods to the interface will break backward compatibility in projects
+ * that use their own driver implementations.
+ *
+ * The methods of this interface can be moved to the main driver interface when upgrading the project's major version.
+ */
+interface DateTimeFormatInterface
+{
+    /**
+     * Returns DateTime format of the driver.
+     */
+    public function getDateTimeFormat(): string;
+}

--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -30,7 +30,7 @@ use Psr\Log\LoggerAwareTrait;
 /**
  * Provides low level abstraction at top of
  */
-abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInterface
+abstract class Driver implements DriverInterface, NamedInterface, DateTimeFormatInterface, LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
@@ -578,9 +578,7 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
             throw new DriverException($e->getMessage(), (int) $e->getCode(), $e);
         }
 
-        return $datetime->format(
-            $this->config->options['withDatetimeMicroseconds'] ? self::DATETIME_MICROSECONDS : self::DATETIME,
-        );
+        return $datetime->format($this->getDateTimeFormat());
     }
 
     /**
@@ -705,5 +703,13 @@ abstract class Driver implements DriverInterface, NamedInterface, LoggerAwareInt
         }
 
         return $context;
+    }
+
+    /**
+     * Returns DateTime format of the driver.
+     */
+    public function getDateTimeFormat(): string
+    {
+        return $this->config->options['withDatetimeMicroseconds'] ? self::DATETIME_MICROSECONDS : self::DATETIME;
     }
 }

--- a/tests/Database/Functional/Driver/Common/Driver/DriverTest.php
+++ b/tests/Database/Functional/Driver/Common/Driver/DriverTest.php
@@ -64,6 +64,24 @@ abstract class DriverTest extends BaseTest
         yield [new class('2000-01-23T01:23:45.678+09:00') extends \DateTime {}];
     }
 
+    /**
+     * @dataProvider dateTimeFormatProvider
+     */
+    public function testGetDateTimeFormat(bool $withDatetimeMicroseconds, string $format): void
+    {
+        $options = [
+            'withDatetimeMicroseconds' => $withDatetimeMicroseconds,
+        ];
+        $driver = $this->db(driverConfig: ['options' => $options])->getDriver();
+        self::assertSame($format, $driver->getDateTimeFormat());
+    }
+
+    public function dateTimeFormatProvider(): \Traversable
+    {
+        yield [false, 'Y-m-d H:i:s'];
+        yield [true, 'Y-m-d H:i:s.u'];
+    }
+
     public function testClearCache(): void
     {
         $driver = $this->mockDriver();


### PR DESCRIPTION
## 🔍 What was changed

A method for obtaining the time storage format has been added to the driver class. To avoid breaking backward compatibility, a separate interface has been allocated for this method.

## 🤔 Why?

In some cases, it is necessary to know in what format time is stored.
For example, see [Issue 66 of cycle/migrations](https://github.com/cycle/migrations/issues/66)

## 📝 Checklist

- How was this tested:
  - [ ] Tested manually
  - [x] Unit tests added
